### PR TITLE
Guarantee YAFM for applying '-' starts with an uppercase letter

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -5,6 +5,8 @@
 
 #include "hack.h"
 
+#include <ctype.h>
+
 extern boolean notonhead; /* for long worms */
 
 STATIC_DCL int FDECL(use_camera, (struct obj *));
@@ -3655,7 +3657,8 @@ doapply()
         return 0;
 
     if (obj == &zeroobj) {
-        pline("%s always said you needed to apply yourself!", ldrname());
+        char const *name = ldrname();
+        pline("%c%s always said you needed to apply yourself!", toupper(name[0]), name + 1);
         return 0;
     }
 

--- a/src/apply.c
+++ b/src/apply.c
@@ -5,8 +5,6 @@
 
 #include "hack.h"
 
-#include <ctype.h>
-
 extern boolean notonhead; /* for long worms */
 
 STATIC_DCL int FDECL(use_camera, (struct obj *));
@@ -3657,8 +3655,8 @@ doapply()
         return 0;
 
     if (obj == &zeroobj) {
-        char const *name = ldrname();
-        pline("%c%s always said you needed to apply yourself!", toupper(name[0]), name + 1);
+        const char *name = ldrname();
+        pline("%c%s always said you needed to apply yourself!", highc(name[0]), name + 1);
         return 0;
     }
 


### PR DESCRIPTION
If `ldrname()` returns a name starting with "the", such as "the Norn", the YAFM would start a sentence with a lowercase letter. 

This is obviously unacceptable.