### PR TITLE
Fix message for wielded moldy corpse

### DIFF
--- a/src/do.c
+++ b/src/do.c
@@ -1876,8 +1876,9 @@ boolean moldy;
         case OBJ_INVENT:
             if (is_uwep) {
                 if (moldy) {
-                    pline_The("moldy %s in your hand grows into a %s!", cname,
-                              mon_nam(mtmp));
+                    pline_The("moldy corpse in your %s grows into a %s!",
+                        body_part(HAND), canspotmon(mtmp) ? a_monnam(mtmp)
+                                                          : "a monster");
                 }
                 else
                     pline_The("%s writhes out of your grasp!", cname);


### PR DESCRIPTION
The previous version would produce messages such as "The moldy lichen corpse in your hand grows into a the lichen!" Now, the message will read "The moldy corpse in your <hand> grows into a lichen!" with <hand> replaced by the appropriate body part. (If the fungus is unseen, the corpse "grows into a monster" rather than "grows into it".)