### PR TITLE
Do not mutate `flags.inv_order` in `query_category`

### DIFF
--- a/src/pickup.c
+++ b/src/pickup.c
@@ -1121,7 +1121,7 @@ int how;               /* type of query */
     int n;
     winid win;
     struct obj *curr;
-    char *pack;
+    char *pack, packbuf[MAXOCLASSES + 1];
     anything any;
     boolean collected_type_name;
     char invlet;
@@ -1181,7 +1181,7 @@ int how;               /* type of query */
     win = create_nhwindow(NHW_MENU);
     start_menu(win, MENU_BEHAVE_STANDARD);
 
-    pack = flags.inv_order;
+    pack = strcpy(packbuf, flags.inv_order);
     if (qflags & INCLUDE_VENOM)
         (void) strkitten(pack, VENOM_CLASS); /* venom is not in inv_order */
 


### PR DESCRIPTION
Fixes the game crashing or malfunctioning after executing <kbd>D</kbd> for several times.

## Symptom

On macOS, the game crashes after executing the following series of commands:
1. <kbd>D</kbd>: Drop by categories
2. <kbd>&nbsp;</kbd>: Cancel
3. <kbd>D</kbd>: Drop by categories
4. <kbd>&nbsp;</kbd>: Cancel
5. <kbd>D</kbd>: Drop by categories
6. <kbd>&nbsp;</kbd>: Cancel
7. <kbd>\`</kbd>: View discoveries

## Analysis

Every time `query_category` is called with `qflags` including `INCLUDE_VENOM` (i.e., when doing <kbd>D</kbd>), it inserts `VENOM_CLASS` (`0x11`) to the back of `flags.inv_order`. When this is repeated, `flags.inv_order` indefinitely gets longer, eventually overflowing into the neighboring field (`pickup_types`). The following annotated memory dump shows the content of `flags.inv_order` after <kbd>D</kbd><kbd>&nbsp;</kbd> is repeated for a few times.

```
(lldb) x $r14
            ,-- the start of flags.inv_order
            |
            v
0x100f84c9e: 0c 05 02 03 07 09 0a 08 04 0b 06 0d 0e 0f 10 11  ................
0x100f84cae: 11 11 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
                  ^  ^
                  |  |
                  |  '-- flags.inv_order's content actually ends here
                  |
                  '-- the end of flags.inv_order
                      the start of flags.pickup_types
```

If <kbd>D</kbd><kbd>&nbsp;</kbd> is repeated further, it eventually corrupts `flags.menu_style` and <kbd>D</kbd> will start displaying the traditional style menu.

The `doclassdisco` function (<kbd>\`</kbd>) and some others copy the content of `flags.inv_order` into a local variable of type `char[MAXOCLASSES]`. When a byte sequence longer than `MAXOCLASSES` is copied into that variable, the secure `strcpy` function provided by some platforms detects buffer overflow and terminates the program.

## Cause

`query_category` is not supposed to modify `flags.inv_order`. This bug was apparently introduced by commit 2863906 ("Merge commit '60dbb4c12' into dec2020-vanilla-merge").

286390648782b9e416de06096bb1d16decdfc010:
https://github.com/copperwater/xNetHack/blob/286390648782b9e416de06096bb1d16decdfc010/src/pickup.c#L1184-L1186

36fd1f2a66e192463adc562ddfa01d156ae5e688 (downstream parent commit):
https://github.com/copperwater/xNetHack/blob/36fd1f2a66e192463adc562ddfa01d156ae5e688/src/pickup.c#L1181

60dbb4c12f7facdfb10cade49e61e643be82fdd5 (upstream parent commit):
https://github.com/copperwater/xNetHack/blob/60dbb4c12f7facdfb10cade49e61e643be82fdd5/src/pickup.c#L1160-L1162
