### PR TITLE
Update some criteria for apply getobj prompt

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -3914,8 +3914,10 @@ struct obj *obj;
     if (is_graystone(obj)) {
         /* The only case where we _don't_ apply a gray stone is if we KNOW it
          * isn't a touchstone or a thiefstone. */
-        if (obj->otyp != TOUCHSTONE && objects[TOUCHSTONE].oc_name_known
-            && obj->otyp != THIEFSTONE && objects[THIEFSTONE].oc_name_known
+        if ((obj->otyp != TOUCHSTONE && obj->otyp != THIEFSTONE)
+            && (objects[obj->otyp].oc_name_known
+                || (objects[TOUCHSTONE].oc_name_known
+                    && objects[THIEFSTONE].oc_name_known))
             && obj->dknown)
             return 0;
         else

--- a/src/apply.c
+++ b/src/apply.c
@@ -3902,6 +3902,9 @@ struct obj *obj;
     if (obj->oclass == TOOL_CLASS || is_pole(obj) || is_axe(obj))
         return 2;
 
+    if (obj->oclass == WAND_CLASS)
+        return 2;
+
     if (obj->oclass == POTION_CLASS &&
         (obj->otyp == POT_OIL || !obj->dknown ||
          (!objects[obj->otyp].oc_name_known &&


### PR DESCRIPTION
This would update the `getobj` prompt for <kbd>a</kbd>pply so that wands are listed, fixing the secondary complaint in #15 (the main problem described in that issue is unrelated).

It would also update the way gray stones are listed; a comment in `apply_ok` suggests gray stones should be listed by default and excluded once they are known to be something other than a touchstone or thiefstone, but the actual heuristic currently applied is not totally in line with that rule -- only gray stones identified through the process of elimination (e.g. something still listed as a "gray stone" once thiefstones and touchstones had been identified) are excluded.  This patch would also exclude stones that have been identified through a scroll of identify and found to be something other than a touchstone or thiefstone.