### PR TITLE
Remove forced definition of CURSES_GRAPHICS

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -54,7 +54,6 @@
  */
 #if !defined(NOTTYGRAPHICS)
 #define TTY_GRAPHICS /* good old tty based graphics */
-#define CURSES_GRAPHICS
 #endif
 /* #define CURSES_GRAPHICS *//* Curses interface - Karl Garrison*/
 /* #define X11_GRAPHICS */   /* X11 interface */


### PR DESCRIPTION
Attempting to compile and link xNetHack with TTY as the sole windowing system currently fails, because despite curses not actually being included, `CURSES_GRAPHICS` will still be defined in config.h alongside `TTY_GRAPHICS`.

I'm not sure what the reason for this is; removing the definition does not prevent compiling xNetHack with curses or have any negative effects that I can see (the line is not included in [vanilla NetHack's config.h](https://github.com/NetHack/NetHack/blob/b8cb4ec81da2c599f1c261a5979f8bbd1612b883/include/config.h#L51-L61)), but it does make compilation and linking work correctly when TTY is the only windowing system.

With the `#define CURSES_GRAPHICS` line in config.h, here's a sample of `make all` output on my system:

    ( cd src ; make xnethack )
    make[1]: Entering directory '/Users/entrez/github/xnethack/src'
    Linking xnethack.
    Undefined symbols for architecture x86_64:
      "_curses_fmt_attrs", referenced from:
          _optfn_petattr in options.o
      "_curses_procs", referenced from:
          _winchoices in windows.o
      "_curses_read_attrs", referenced from:
          _optfn_petattr in options.o
          _optfn_boolean in options.o
    ld: symbol(s) not found for architecture x86_64
    clang: error: linker command failed with exit code 1 (use -v to see invocation)
    make[1]: *** [Makefile:873: Sysunix] Error 1
    make[1]: Leaving directory '/Users/entrez/github/xnethack/src'
    make: *** [Makefile:341: xnethack] Error 2

I think the solution is just to remove the "forced" definition of `CURSES_GRAPHICS` from config.h, which is what I have done in this PR; if the curses windowing system is being deliberately included, `CURSES_GRAPHICS` will be defined anyway via the hints file/makefile:
https://github.com/copperwater/xNetHack/blob/09d2513991b27a9b2ab430a1eb28fa9ba9473fda/sys/unix/hints/macosx10.14#L101-L106
https://github.com/copperwater/xNetHack/blob/09d2513991b27a9b2ab430a1eb28fa9ba9473fda/sys/unix/hints/linux#L30