### PR TITLE
Thiefstone gold golem teleportation updates

### DIFF
--- a/src/apply.c
+++ b/src/apply.c
@@ -2538,6 +2538,11 @@ struct obj *tstone;
             else
                 pline("You make scratch marks on the stone.");
         }
+        else if (g.youmonst.data == &mons[PM_GOLD_GOLEM]
+                 && tstone->otyp == THIEFSTONE && tstone->blessed
+                 && !u.uhave.amulet) {
+            thiefstone_tele_mon(tstone, &g.youmonst);
+        }
         else {
             pline("You rub the stone on your %s.", body_part(HAND));
             pline("It's not very interesting.");

--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -1036,23 +1036,7 @@ boolean hitsroof;
     } else if (obj->otyp == THIEFSTONE && obj->blessed &&
                g.youmonst.data == &mons[PM_GOLD_GOLEM] &&
                !u.uhave.amulet) {
-        /* the thiefstone sees you as valuable treasure and steals you away! */
-        /* prevent it from angering a shopkeeper, if you're in a shop */
-        obj->no_charge = 1;
-        pline_The("thiefstone steals you away!");
-        if (obj->keyed_ledger == ledger_no(&u.uz)) {
-            teleds(keyed_x(obj), keyed_y(obj), TELEDS_NO_FLAGS);
-        } else {
-            d_level newlev;
-            newlev.dnum = ledger_to_dnum(obj->keyed_ledger);
-            newlev.dlevel = ledger_to_dlev(obj->keyed_ledger);
-            /* goto_level currently doesn't allow you to arrive at an exact
-             * location so let's assume that arriving on the same level is good
-             * enough */
-            /* schedule_goto(&newlev, FALSE, FALSE, FALSE, NULL, NULL); */
-            goto_level(&newlev, FALSE, FALSE, FALSE);
-            teleds(keyed_x(obj), keyed_y(obj), TELEDS_NO_FLAGS);
-        }
+        thiefstone_tele_mon(obj, &g.youmonst);
         thiefstone_teleport(obj, obj);
         return FALSE;
     } else if (breaktest(obj)) {

--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -1802,8 +1802,6 @@ register struct obj *obj; /* g.thrownobj or g.kickedobj or uwep */
                 /* prevent hero from paying for thiefstone */
                 obj->no_charge = 1;
                 if (canspotmon(mon)) {
-                    /* only instance of thiefstone teleporting something not on
-                     * the hero's space */
                     pline("%s touches %s, and they both disappear!",
                           Yname2(obj), mon_nam(mon));
                     makeknown(THIEFSTONE);

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -1771,7 +1771,8 @@ struct monst* mon;
     else {
         if (ledger == ledger_no(&u.uz)) {
             /* same level, just do horizontal teleport */
-            enexto(&cc, keyed_x(stone), keyed_y(stone), mon->data);
+            if (!goodpos(cc.x, cc.y, mon, 0))
+                enexto(&cc, cc.x, cc.y, mon->data);
             rloc_to(mon, cc.x, cc.y);
         } else {
             /* level teleport mon */

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -1746,15 +1746,37 @@ struct monst* mon;
         impossible("thiefstone_tele_mon: bad monster to teleport");
         return;
     }
-    if (ledger == ledger_no(&u.uz)) {
-        /* same level, just do horizontal teleport */
-        enexto(&cc, keyed_x(stone), keyed_y(stone), mon->data);
-        rloc_to(mon, cc.x, cc.y);
-    } else {
-        /* level teleport mon */
-        cc.x = keyed_x(stone);
-        cc.y = keyed_y(stone);
-        migrate_to_level(mon, ledger, MIGR_EXACT_XY, &cc);
+
+    cc.x = keyed_x(stone);
+    cc.y = keyed_y(stone);
+
+    if (mon == &g.youmonst) {
+        /* the thiefstone sees you as valuable treasure and steals you away! */
+        /* can't use a thiefstone to skip the ascension run */
+        if (u.uhave.amulet)
+            return;
+        /* prevent it from angering a shopkeeper, if you're in a shop */
+        stone->no_charge = 1;
+        pline_The("thiefstone steals you away!");
+        if (ledger == ledger_no(&u.uz)) {
+            teleds(cc.x, cc.y, TELEDS_NO_FLAGS);
+        } else {
+            d_level newlev;
+            newlev.dnum = ledger_to_dnum(ledger);
+            newlev.dlevel = ledger_to_dlev(ledger);
+            goto_level(&newlev, FALSE, FALSE, FALSE);
+            teleds(cc.x, cc.y, TELEDS_NO_FLAGS);
+        }
+    }
+    else {
+        if (ledger == ledger_no(&u.uz)) {
+            /* same level, just do horizontal teleport */
+            enexto(&cc, keyed_x(stone), keyed_y(stone), mon->data);
+            rloc_to(mon, cc.x, cc.y);
+        } else {
+            /* level teleport mon */
+            migrate_to_level(mon, ledger, MIGR_EXACT_XY, &cc);
+        }
     }
 }
 


### PR DESCRIPTION
Teleport the hero when they rub a thiefstone on their hands while polymorphed into a gold golem, and teleport non-player gold golems when hitting them with a wielded thiefstone.