### PR TITLE
Cause some dwarves to be avid tipplers

### DIFF
--- a/src/makemon.c
+++ b/src/makemon.c
@@ -354,6 +354,11 @@ m_initweap(register struct monst *mtmp)
             while (!rn2(3))
                 (void) mongets(mtmp, APPLE + rn2(CARROT - APPLE));
         } else if (is_dwarf(ptr)) {
+            if (!rn2(In_mines(&u.uz) ? 40 : 8)) {
+                otmp = mongets(mtmp, POT_BOOZE);
+                otmp->quan = rnd(3);
+                otmp->owt = weight(otmp);
+            }
             if (rn2(7))
                 (void) mongets(mtmp, DWARVISH_CLOAK);
             if (rn2(7))


### PR DESCRIPTION
The occasional dwarf carries a hefty personal supply of booze potions (3).

Went for a more notable occasional big stack, rather than a steady dribble of unexciting single potions a la nymphs.