### PR TITLE
GitHub actions: mingw build

### DIFF
--- a/.github/workflows/build-c.yml
+++ b/.github/workflows/build-c.yml
@@ -7,41 +7,38 @@ on:
     branches: [ master ]
 
 jobs:
-#  linux-build:
-#
-#    runs-on: ubuntu-latest
-#    
-#    env: 
-#      #LUA_VERSION: 5.4.2
-#      HINTS_FILE: linux.2020
-#
-#    steps:
-#    - uses: actions/checkout@v2
-#    - name: setup
-#      run: ./sys/unix/setup.sh sys/unix/hints/$HINTS_FILE
-#    - name: fetch lua
-#      run: |
-#        make fetch-lua
-#    - name: make all
-#      run: make -j8 all
-#    - name: make install
-#      run: make install
-#      
-#  mac-build:
-#    runs-on: macos-latest
-#    env:
-#      HINTS_FILE: macOS.2020
-#    steps:
-#    - uses: actions/checkout@v2
-#    - name: setup
-#      run: |
-#        ./sys/unix/setup.sh sys/unix/hints/$HINTS_FILE
-#        make fetch-lua
-#    - name: make all
-#      run: make -j8 all
-#    - name: make install
-#      run: make install
-    
+  linux-build:
+    runs-on: ubuntu-latest
+    env: 
+      #LUA_VERSION: 5.4.2
+      HINTS_FILE: linux.2020
+    steps:
+    - uses: actions/checkout@v2
+    - name: setup
+      run: ./sys/unix/setup.sh sys/unix/hints/$HINTS_FILE
+    - name: fetch lua
+      run: |
+        make fetch-lua
+    - name: make all
+      run: make -j8 all
+    - name: make install
+      run: make install
+
+  mac-build:
+    runs-on: macos-latest
+    env:
+      HINTS_FILE: macOS.2020
+    steps:
+    - uses: actions/checkout@v2
+    - name: setup
+      run: |
+        ./sys/unix/setup.sh sys/unix/hints/$HINTS_FILE
+        make fetch-lua
+    - name: make all
+      run: make -j8 all
+    - name: make install
+      run: make install
+
   windows-build:
     runs-on: windows-latest
     env:

--- a/.github/workflows/build-c.yml
+++ b/.github/workflows/build-c.yml
@@ -44,20 +44,27 @@ jobs:
     
   windows-build:
     runs-on: windows-latest
+    env:
+        ADD_LUA: Y
+        WANT_LUAC: N
+        LUATOP: ../submodules/lua
+        LUASRC: ../submodules/lua
+        ADD_CURSES: Y
+        PDCURSES_TOP: ../submodules/pdcurses
+        LUA_VERSION: 5.4.2
+        TRAVIS_COMPILER: 1
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: recursive
     - name: setup
       run: |
         ./sys/winnt/nhsetup.bat
     - name: make all
       run: |
         cd src
-        nmake install
-      #mingw32-make -f Makefile.gcc install
-
-
-
-
+        cp ../sys/winnt/Makefile.gcc ./Makefile
+        mingw32-make LUA_VERSION=$LUA_VERSION install
 
 
 

--- a/sys/winnt/Makefile.gcc
+++ b/sys/winnt/Makefile.gcc
@@ -169,7 +169,7 @@ SKIP_NETHACKW=Y
 #==============================================================================
 
 #  The version of the game this Makefile was designed for
-NETHACK_VERSION="3.7.0"
+NETHACK_VERSION="6.0.0"
 
 # A brief version for use in macros
 NHV1=$(subst .,,$(NETHACK_VERSION))
@@ -312,27 +312,27 @@ VOBJ04 = $(O)dig.o      $(O)display.o  $(O)do.o       $(O)do_name.o
 VOBJ05 = $(O)do_wear.o  $(O)dog.o      $(O)dogmove.o  $(O)dokick.o
 VOBJ06 = $(O)dothrow.o  $(O)drawing.o  $(O)dungeon.o  $(O)eat.o
 VOBJ07 = $(O)end.o      $(O)engrave.o  $(O)exper.o    $(O)explode.o
-VOBJ08 = $(O)extralev.o $(O)files.o    $(O)fountain.o $(O)hack.o
-VOBJ09 = $(O)hacklib.o  $(O)insight.o  $(O)invent.o   $(O)isaac64.o
-VOBJ10 = $(O)light.o    $(O)lock.o     $(O)mail.o     $(O)makemon.o
-VOBJ11 = $(O)mdlib.o    $(O)mcastu.o   $(O)mhitm.o    $(O)mhitu.o
-VOBJ12 = $(O)minion.o   $(O)mklev.o    $(O)mkmap.o    $(O)mkmaze.o
-VOBJ13 = $(O)mkobj.o    $(O)mkroom.o   $(O)mon.o      $(O)mondata.o
-VOBJ14 = $(O)monmove.o  $(O)monst.o    $(O)mplayer.o  $(O)mthrowu.o
-VOBJ15 = $(O)muse.o     $(O)music.o    $(O)o_init.o   $(O)objects.o 
-VOBJ16 = $(O)objnam.o   $(O)options.o  $(O)pager.o    $(O)pickup.o
-VOBJ17 = $(O)pline.o    $(O)polyself.o $(O)potion.o   $(O)pray.o
-VOBJ18 = $(O)priest.o   $(O)quest.o    $(O)questpgr.o $(RANDOM)
-VOBJ19 = $(O)read.o     $(O)rect.o     $(O)region.o   $(O)restore.o
-VOBJ20 = $(O)rip.o      $(O)rnd.o      $(O)role.o     $(O)rumors.o
-VOBJ21 = $(O)save.o     $(O)sfstruct.o $(O)shk.o      $(O)shknam.o
-VOBJ22 = $(O)sit.o      $(O)sounds.o   $(O)sp_lev.o   $(O)spell.o
-VOBJ23 = $(O)steal.o    $(O)steed.o    $(O)symbols.o  $(O)sys.o
-VOBJ24 = $(O)teleport.o $(O)timeout.o  $(O)topten.o   $(O)track.o
-VOBJ25 = $(O)trap.o     $(O)u_init.o   $(O)uhitm.o    $(O)vault.o
-VOBJ26 = $(O)vision.o   $(O)weapon.o   $(O)were.o     $(O)wield.o
-VOBJ27 = $(O)windows.o  $(O)wizard.o   $(O)worm.o     $(O)worn.o
-VOBJ28 = $(O)write.o    $(O)zap.o
+VOBJ08 = $(O)files.o    $(O)fountain.o $(O)hack.o     $(O)hacklib.o
+VOBJ09 = $(O)insight.o  $(O)invent.o   $(O)isaac64.o  $(O)light.o
+VOBJ10 = $(O)lock.o     $(O)mail.o     $(O)makemon.o  $(O)mdlib.o
+VOBJ11 = $(O)mcastu.o   $(O)mhitm.o    $(O)mhitu.o    $(O)minion.o
+VOBJ12 = $(O)mklev.o    $(O)mkmap.o    $(O)mkmaze.o   $(O)mkobj.o
+VOBJ13 = $(O)mkroom.o   $(O)mon.o      $(O)mondata.o  $(O)monmove.o
+VOBJ14 = $(O)monst.o    $(O)mplayer.o  $(O)mthrowu.o  $(O)muse.o
+VOBJ15 = $(O)music.o    $(O)o_init.o   $(O)objects.o  $(O)objnam.o
+VOBJ16 = $(O)options.o  $(O)pager.o    $(O)pickup.o   $(O)pline.o
+VOBJ17 = $(O)polyself.o $(O)potion.o   $(O)pray.o     $(O)priest.o
+VOBJ18 = $(O)quest.o    $(O)questpgr.o $(RANDOM)      $(O)read.o
+VOBJ19 = $(O)rect.o     $(O)region.o   $(O)restore.o  $(O)rip.o
+VOBJ20 = $(O)rnd.o      $(O)role.o     $(O)rumors.o   $(O)save.o
+VOBJ21 = $(O)sfstruct.o $(O)shk.o      $(O)shknam.o   $(O)sit.o
+VOBJ22 = $(O)sounds.o   $(O)sp_lev.o   $(O)spell.o    $(O)steal.o
+VOBJ23 = $(O)steed.o    $(O)symbols.o  $(O)sys.o      $(O)teleport.o
+VOBJ24 = $(O)timeout.o  $(O)topten.o   $(O)track.o    $(O)trap.o
+VOBJ25 = $(O)u_init.o   $(O)uhitm.o    $(O)vault.o    $(O)vision.o
+VOBJ26 = $(O)weapon.o   $(O)were.o     $(O)wield.o    $(O)windows.o
+VOBJ27 = $(O)wizard.o   $(O)worm.o     $(O)worn.o     $(O)write.o
+VOBJ28 = $(O)zap.o
 
 ifeq "$(ADD_LUA)" "Y"
 LUAOBJ = $(O)nhlua.o    $(O)nhlsel.o    $(O)nhlobj.o
@@ -1627,7 +1627,6 @@ $(O)end.o: end.c $(HACK_H) $(INCL)/dlb.h
 $(O)engrave.o: engrave.c $(HACK_H)
 $(O)exper.o: exper.c $(HACK_H)
 $(O)explode.o: explode.c $(HACK_H)
-$(O)extralev.o: extralev.c $(HACK_H)
 $(O)files.o: files.c $(HACK_H) $(INCL)/dlb.h
 $(O)fountain.o: fountain.c $(HACK_H)
 $(O)hack.o: hack.c $(HACK_H)

--- a/sys/winnt/Makefile.msc
+++ b/sys/winnt/Makefile.msc
@@ -168,7 +168,7 @@ LUATOP=..\lib\lua-$(LUAVER)
 #==============================================================================
 #
 #  The version of the game this Makefile was designed for
-NETHACK_VERSION="3.7.0"
+NETHACK_VERSION="6.0.0"
 
 # A brief version for use in macros
 NHV=$(NETHACK_VERSION:.=)
@@ -297,27 +297,26 @@ VOBJ04 = $(O)dig.o      $(O)display.o  $(O)do.o       $(O)do_name.o
 VOBJ05 = $(O)do_wear.o  $(O)dog.o      $(O)dogmove.o  $(O)dokick.o
 VOBJ06 = $(O)dothrow.o  $(O)drawing.o  $(O)dungeon.o  $(O)eat.o
 VOBJ07 = $(O)end.o      $(O)engrave.o  $(O)exper.o    $(O)explode.o
-VOBJ08 = $(O)extralev.o $(O)files.o    $(O)fountain.o $(O)hack.o
-VOBJ09 = $(O)hacklib.o  $(O)insight.o  $(O)invent.o   $(O)isaac64.o
-VOBJ10 = $(O)light.o    $(O)lock.o     $(O)mail.o     $(O)makemon.o
-VOBJ11 = $(O)mcastu.o   $(O)mhitm.o    $(O)mhitu.o    $(O)minion.o
-VOBJ12 = $(O)mklev.o    $(O)mkmap.o    $(O)mkmaze.o   $(O)mkobj.o
-VOBJ13 = $(O)mkroom.o   $(O)mon.o      $(O)mondata.o  $(O)monmove.o
-VOBJ14 = $(O)monst.o    $(O)mplayer.o  $(O)mthrowu.o  $(O)muse.o
-VOBJ15 = $(O)music.o    $(O)o_init.o   $(O)objects.o  $(O)objnam.o
-VOBJ16 = $(O)options.o  $(O)pager.o    $(O)pickup.o   $(O)pline.o
-VOBJ17 = $(O)polyself.o $(O)potion.o   $(O)pray.o     $(O)priest.o
-VOBJ18 = $(O)quest.o    $(O)questpgr.o $(RANDOM)      $(O)read.o
-VOBJ19 = $(O)rect.o     $(O)region.o   $(O)restore.o  $(O)rip.o
-VOBJ20 = $(O)rnd.o      $(O)role.o     $(O)rumors.o   $(O)save.o
-VOBJ21 = $(O)sfstruct.o $(O)shk.o      $(O)shknam.o   $(O)sit.o
-VOBJ22 = $(O)sounds.o   $(O)sp_lev.o   $(O)spell.o    $(O)steal.o
-VOBJ23 = $(O)steed.o    $(O)symbols.o  $(O)sys.o      $(O)teleport.o
-VOBJ24 = $(O)timeout.o  $(O)topten.o   $(O)track.o    $(O)trap.o
-VOBJ25 = $(O)u_init.o   $(O)uhitm.o    $(O)vault.o    $(O)vision.o
-VOBJ26 = $(O)weapon.o   $(O)were.o     $(O)wield.o    $(O)windows.o
-VOBJ27 = $(O)wizard.o   $(O)worm.o     $(O)worn.o     $(O)write.o
-VOBJ28 = $(O)zap.o
+VOBJ08 = $(O)files.o    $(O)fountain.o $(O)hack.o     $(O)hacklib.o
+VOBJ09 = $(O)insight.o  $(O)invent.o   $(O)isaac64.o  $(O)light.o
+VOBJ10 = $(O)lock.o     $(O)mail.o     $(O)makemon.o  $(O)mcastu.o
+VOBJ11 = $(O)mhitm.o    $(O)mhitu.o    $(O)minion.o   $(O)mklev.o
+VOBJ12 = $(O)mkmap.o    $(O)mkmaze.o   $(O)mkobj.o    $(O)mkroom.o
+VOBJ13 = $(O)mon.o      $(O)mondata.o  $(O)monmove.o  $(O)monst.o
+VOBJ14 = $(O)mplayer.o  $(O)mthrowu.o  $(O)muse.o     $(O)music.o
+VOBJ15 = $(O)o_init.o   $(O)objects.o  $(O)objnam.o   $(O)options.o
+VOBJ16 = $(O)pager.o    $(O)pickup.o   $(O)pline.o    $(O)polyself.o
+VOBJ17 = $(O)potion.o   $(O)pray.o     $(O)priest.o   $(O)quest.o
+VOBJ18 = $(O)questpgr.o $(RANDOM)      $(O)read.o     $(O)rect.o
+VOBJ19 = $(O)region.o   $(O)restore.o  $(O)rip.o      $(O)rnd.o
+VOBJ20 = $(O)role.o     $(O)rumors.o   $(O)save.o     $(O)sfstruct.o
+VOBJ21 = $(O)shk.o      $(O)shknam.o   $(O)sit.o      $(O)sounds.o
+VOBJ22 = $(O)sp_lev.o   $(O)spell.o    $(O)steal.o    $(O)steed.o
+VOBJ23 = $(O)symbols.o  $(O)sys.o      $(O)teleport.o $(O)timeout.o
+VOBJ24 = $(O)topten.o   $(O)track.o    $(O)trap.o     $(O)u_init.o
+VOBJ25 = $(O)uhitm.o    $(O)vault.o    $(O)vision.o   $(O)weapon.o
+VOBJ26 = $(O)were.o     $(O)wield.o    $(O)windows.o  $(O)wizard.o
+VOBJ27 = $(O)worm.o     $(O)worn.o     $(O)write.o    $(O)zap.o
 
 LUAOBJ = $(O)nhlua.o    $(O)nhlsel.o    $(O)nhlobj.o
 
@@ -348,8 +347,8 @@ OBJS   = $(MDLIB) \
 	$(VOBJ11) $(VOBJ12) $(VOBJ13) $(VOBJ14) $(VOBJ15) \
 	$(VOBJ16) $(VOBJ17) $(VOBJ18) $(VOBJ19) $(VOBJ20) \
 	$(VOBJ21) $(VOBJ22) $(VOBJ23) $(VOBJ24) $(VOBJ25) \
-	$(VOBJ26) $(VOBJ27) $(VOBJ28) $(VOBJ29) $(VOBJ30) \
-	$(REGEX)  $(CURSESOBJ)
+	$(VOBJ26) $(VOBJ27) $(VOBJ29) $(VOBJ30) $(REGEX)  \
+	$(CURSESOBJ)
 
 WINDHDR = $(MSWSYS)\win10.h $(MSWSYS)\winos.h $(MSWSYS)\win32api.h
 
@@ -1970,7 +1969,6 @@ $(O)end.o: end.c $(HACK_H) $(INCL)\dlb.h
 $(O)engrave.o: engrave.c $(HACK_H)
 $(O)exper.o: exper.c $(HACK_H)
 $(O)explode.o: explode.c $(HACK_H)
-$(O)extralev.o: extralev.c $(HACK_H)
 $(O)files.o: files.c $(HACK_H) $(INCL)\dlb.h #zlib.h
 $(O)fountain.o: fountain.c $(HACK_H)
 $(O)hack.o: hack.c $(HACK_H)

--- a/sys/winnt/nttty.c
+++ b/sys/winnt/nttty.c
@@ -905,6 +905,13 @@ term_start_color(int color)
 }
 
 void
+term_start_bgcolor(int color)
+{
+    nhUse(color);
+    /* empty */
+}
+
+void
 term_end_color(void)
 {
 #ifdef TEXTCOLOR


### PR DESCRIPTION
[I got the Windows build running](https://github.com/entrez/xNetHack/actions/runs/666312845).

One issue: the TTY windowport has a function, `term_start_bgcolor`, which is used only for the `hilite_hidden_stairs` setting.  Because there was no Windows NT TTY equivalent to this function, the Windows build was broken.  I just created an empty placeholder in sys/winnt/nttty.c because I don't know how the NT TTY windowport works at all; at least this gets the Windows build working, but obviously the `hilite_hidden_stairs` option will be useless.