### PR TITLE
Some statue-related fixes

### DIFF
--- a/src/makemon.c
+++ b/src/makemon.c
@@ -1292,13 +1292,23 @@ makemon(register struct permonst *ptr,
             /* Generate a couple random statues near a petrifier, but only if
              * it's not being generated in a zoo or nest or other special room.
              */
+            struct obj *sobj;
             do {
                 int tries = 20;
                 while (tries--) {
                     int dx = 5 - rn2(11), dy = 5 - rn2(11); /* -5 .. +5 */
                     if (isok(x + dx, y + dy)
                         && ACCESSIBLE(levl[x + dx][y + dy].typ)) {
-                        mksobj_at(STATUE, x + dx, y + dy, TRUE, FALSE);
+                        sobj = mksobj_at(STATUE, x + dx, y + dy, TRUE, FALSE);
+                        if (!sobj) {
+                            continue;
+                        }
+                        if (poly_when_stoned(&mons[sobj->corpsenm])
+                            || (mons[sobj->corpsenm].mresists & MR_STONE)) {
+                            delobj(sobj);
+                            continue;
+                        }
+                        set_material(sobj, MINERAL);
                         break;
                     }
                 }

--- a/src/mkroom.c
+++ b/src/mkroom.c
@@ -502,6 +502,7 @@ fill_zoo(struct mkroom* sroom)
                     struct obj *sobj = mk_tt_object(STATUE, sx, sy);
 
                     if (sobj) {
+                        set_material(sobj, MINERAL);
                         for (i = rn2(5); i; i--)
                             (void) add_to_container(
                                 sobj, mkobj(RANDOM_CLASS, FALSE));

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -28,7 +28,8 @@ getroomtype(xchar x, xchar y)
 {
     int rno = levl[x][y].roomno;
     if (rno >= ROOMOFFSET) {
-        return g.rooms[rno - ROOMOFFSET].orig_rtype;
+        return g.in_mklev ? g.rooms[rno - ROOMOFFSET].rtype
+                          : g.rooms[rno - ROOMOFFSET].orig_rtype;
     }
     /* not a room */
     return OROOM;


### PR DESCRIPTION
Intended to address some statue-related problems I noticed.

1. Random statues generated near cockatrice on level creation can be stoning-resistant monsters.
2. Random statues generated near cockatrice on level creation may be made of other materials than stone.
3. Statues generated in cockatrice nest when high score list is empty may be stoning-resistant monsters (vanilla bug); they can also be made of materials other than stone.
4. Random statues generated on Medusa level can be poly_when_stoned monsters (vanilla bug)
5. A comment on makemon.c:1296 says statues should be produced near footrices only when they are generated randomly in a normal room, but random statues are still generated in nests.

I submitted fixes to the issues marked "(vanilla bug)" in NetHack/NetHack#479; currently this PR only includes xNetHack-specific fixes.
