### PR TITLE
Prevent noise from uncloaking mimics

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1477,7 +1477,7 @@ extern void maybe_mnexto(struct monst *);
 extern int mnearto(struct monst *, xchar, xchar, boolean);
 extern void m_respond(struct monst *);
 extern void setmangry(struct monst *, boolean);
-extern void wakeup(struct monst *, boolean);
+extern void wakeup(struct monst *, boolean, boolean);
 extern void wake_nearby(void);
 extern void wake_nearto(int, int, int);
 extern void seemimic(struct monst *);

--- a/src/apply.c
+++ b/src/apply.c
@@ -709,7 +709,7 @@ use_leash(struct obj *obj)
                 spotmon ? y_monnam(mtmp) : l_monnam(mtmp));
             mtmp->mleashed = 1;
             obj->leashmon = (int) mtmp->m_id;
-            wakeup(mtmp, FALSE);
+            wakeup(mtmp, FALSE, FALSE);
             update_inventory();
         }
     } else {
@@ -2984,7 +2984,7 @@ use_whip(struct obj *obj)
                 pline1(msg_slipsfree);
             }
             if (mtmp)
-                wakeup(mtmp, TRUE);
+                wakeup(mtmp, TRUE, TRUE);
         } else
             pline1(msg_snap);
 
@@ -3077,7 +3077,7 @@ use_whip(struct obj *obj)
             } else {
                 pline1(msg_slipsfree);
             }
-            wakeup(mtmp, TRUE);
+            wakeup(mtmp, TRUE, TRUE);
         } else {
             if (M_AP_TYPE(mtmp) && !Protection_from_shape_changers
                 && !sensemon(mtmp))

--- a/src/apply.c
+++ b/src/apply.c
@@ -709,7 +709,7 @@ use_leash(struct obj *obj)
                 spotmon ? y_monnam(mtmp) : l_monnam(mtmp));
             mtmp->mleashed = 1;
             obj->leashmon = (int) mtmp->m_id;
-            wakeup(mtmp, FALSE, FALSE);
+            wakeup(mtmp, FALSE, TRUE);
             update_inventory();
         }
     } else {

--- a/src/dig.c
+++ b/src/dig.c
@@ -2093,7 +2093,7 @@ bury_monst(struct monst *mtmp)
     }
 
     mtmp->mburied = TRUE;
-    wakeup(mtmp, FALSE);       /* at least give it a chance :-) */
+    wakeup(mtmp, FALSE, TRUE);  /* at least give it a chance :-) */
     newsym(mtmp->mx, mtmp->my);
 }
 
@@ -2323,7 +2323,7 @@ create_pit_under(struct monst *mdef, struct monst *magr)
         }
     }
     else {
-        wakeup(mdef, FALSE);
+        wakeup(mdef, FALSE, TRUE);
         /* We want to make them be in the trap anew - they won't fall into holes
          * and such if this is left as 1. */
         mdef->mtrapped = 0;

--- a/src/dokick.c
+++ b/src/dokick.c
@@ -295,7 +295,7 @@ ghitm(register struct monst *mtmp, register struct obj *gold)
 
     if (!likes_gold(mtmp->data) && !mtmp->isshk && !mtmp->ispriest
         && !mtmp->isgd && !is_mercenary(mtmp->data)) {
-        wakeup(mtmp, TRUE);
+        wakeup(mtmp, TRUE, TRUE);
     } else if (!mtmp->mcanmove) {
         /* too light to do real damage */
         if (canseemon(mtmp)) {
@@ -306,7 +306,7 @@ ghitm(register struct monst *mtmp, register struct obj *gold)
     } else {
         long umoney, value = gold->quan * objects[gold->otyp].oc_cost;
 
-        wakeup(mtmp, FALSE);
+        wakeup(mtmp, FALSE, TRUE);
         if (!mtmp->isgd && !rn2(4)) /* not always pleasing */
             setmangry(mtmp, TRUE);
         /* greedy monsters catch gold */

--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -757,7 +757,7 @@ hurtle_step(genericptr_t arg, int x, int y)
             You("find %s by bumping into %s.", mnam, pronoun);
         else
             You("bump into %s.", mnam);
-        wakeup(mon, FALSE);
+        wakeup(mon, FALSE, TRUE);
         if (!canspotmon(mon))
             map_invisible(mon->mx, mon->my);
         setmangry(mon, FALSE);
@@ -1561,7 +1561,7 @@ omon_adj(struct monst *mon, struct obj *obj, boolean mon_notices)
     if (mon->msleeping) {
         tmp += 2;
         if (mon_notices)
-            wakeup(mon, FALSE);
+            wakeup(mon, FALSE, FALSE);
     }
     /* ditto for immobilized target */
     if (!mon->mcanmove || !mon->data->mmove) {
@@ -1605,7 +1605,7 @@ tmiss(struct obj *obj, struct monst *mon, boolean maybe_wakeup)
     else
         miss(missile, mon);
     if (maybe_wakeup && !rn2(3))
-        wakeup(mon, TRUE);
+        wakeup(mon, TRUE, TRUE);
     return;
 }
 
@@ -1864,7 +1864,7 @@ thitmonst(register struct monst *mon,
         } else {
             tmiss(obj, mon, TRUE);
             if (hmode == HMON_APPLIED)
-                wakeup(mon, TRUE);
+                wakeup(mon, TRUE, TRUE);
         }
 
     } else if (otyp == HEAVY_IRON_BALL) {
@@ -1907,12 +1907,12 @@ thitmonst(register struct monst *mon,
             return 1; /* obj is gone */
         } else {
             tmiss(obj, mon, FALSE);
-            wakeup(mon, FALSE);
+            wakeup(mon, FALSE, FALSE);
             mon->mstrategy &= ~STRAT_WAITMASK;
         }
     } else if (guaranteed_hit) {
         /* this assumes that guaranteed_hit is due to swallowing */
-        wakeup(mon, TRUE);
+        wakeup(mon, TRUE, TRUE);
         if (obj->otyp == CORPSE && touch_petrifies(&mons[obj->corpsenm])) {
             if (is_animal(u.ustuck->data)) {
                 minstapetrify(u.ustuck, TRUE);

--- a/src/hack.c
+++ b/src/hack.c
@@ -1596,7 +1596,7 @@ domove_core(void)
                     if (!u.ustuck->mcanmove) {
                         /* it's free to move on next turn */
                         u.ustuck->mfrozen = 1;
-                        wakeup(u.ustuck, FALSE);
+                        wakeup(u.ustuck, FALSE, FALSE);
                     }
                 /*FALLTHRU*/
                 default:
@@ -2788,7 +2788,7 @@ check_special_room(boolean newlev)
                     if (DEADMONSTER(mtmp))
                         continue;
                     if (!Stealth && !rn2(3))
-                        wakeup(mtmp, FALSE);
+                        wakeup(mtmp, FALSE, FALSE);
                 }
         }
     }

--- a/src/mhitm.c
+++ b/src/mhitm.c
@@ -311,7 +311,7 @@ mattackm(register struct monst *magr, register struct monst *mdef)
     tmp = find_mac(mdef) + magr->m_lev;
     if (mdef->mconf || !mdef->mcanmove || mdef->msleeping) {
         tmp += 4;
-        wakeup(mdef, FALSE, FALSE);
+        wakeup(mdef, FALSE, TRUE);
     }
 
     /* undetect monsters become un-hidden if they are attacked */

--- a/src/mhitm.c
+++ b/src/mhitm.c
@@ -212,10 +212,8 @@ mdisplacem(register struct monst *magr, register struct monst *mdef,
     /* undetected monster becomes un-hidden if it is displaced */
     if (mdef->mundetected)
         mdef->mundetected = 0;
-    if (M_AP_TYPE(mdef) && M_AP_TYPE(mdef) != M_AP_MONSTER)
-        seemimic(mdef);
     /* wake up the displaced defender */
-    wakeup(mdef, FALSE);
+    wakeup(mdef, FALSE, TRUE);
     mdef->mstrategy &= ~STRAT_WAITMASK;
 
     /*
@@ -313,7 +311,7 @@ mattackm(register struct monst *magr, register struct monst *mdef)
     tmp = find_mac(mdef) + magr->m_lev;
     if (mdef->mconf || !mdef->mcanmove || mdef->msleeping) {
         tmp += 4;
-        wakeup(mdef, FALSE);
+        wakeup(mdef, FALSE, FALSE);
     }
 
     /* undetect monsters become un-hidden if they are attacked */

--- a/src/mon.c
+++ b/src/mon.c
@@ -3751,6 +3751,9 @@ setmangry(struct monst* mtmp, boolean via_attack)
 void
 wakeup(struct monst* mtmp, boolean via_attack, boolean reveal_hidden)
 {
+    if (DEADMONSTER(mtmp)) {
+        return;
+    }
     boolean was_sleeping = mtmp->msleeping;
     mtmp->msleeping = 0;
     if (reveal_hidden) {

--- a/src/monmove.c
+++ b/src/monmove.c
@@ -253,7 +253,7 @@ disturb(register struct monst* mtmp)
             || (mtmp->data->mlet == S_DOG || mtmp->data->mlet == S_HUMAN)
             || (!rn2(7) && M_AP_TYPE(mtmp) != M_AP_FURNITURE
                 && M_AP_TYPE(mtmp) != M_AP_OBJECT))) {
-        wakeup(mtmp, FALSE);
+        wakeup(mtmp, FALSE, FALSE);
         return 1;
     }
     return 0;
@@ -630,7 +630,7 @@ dochug(register struct monst* mtmp)
             if ((has_telepathy(m2) && (rn2(2) || m2->mblinded))
                 || !rn2(10)) {
                 /* wake it up first, to bring hidden monster out of hiding */
-                wakeup(m2, FALSE);
+                wakeup(m2, FALSE, TRUE);
                 if (cansee(m2->mx, m2->my))
                     pline("It locks on to %s.", mon_nam(m2));
                 m2->mhp -= rnd(15);

--- a/src/mthrowu.c
+++ b/src/mthrowu.c
@@ -323,12 +323,11 @@ ohitmon(
     boolean verbose)/* give message(s) even when you can't see what happened */
 {
     int damage, tmp;
-    boolean vis, ismimic;
+    boolean vis;
     int objgone = 1;
     struct obj *mon_launcher = g.marcher ? MON_WEP(g.marcher) : NULL;
 
     g.notonhead = (g.bhitpos.x != mtmp->mx || g.bhitpos.y != mtmp->my);
-    ismimic = M_AP_TYPE(mtmp) && M_AP_TYPE(mtmp) != M_AP_MONSTER;
     vis = cansee(g.bhitpos.x, g.bhitpos.y);
 
     tmp = 5 + find_mac(mtmp) + omon_adj(mtmp, otmp, FALSE);
@@ -342,7 +341,9 @@ ohitmon(
             tmp += spec_abon(mon_launcher, mtmp);
     }
     if (tmp < rnd(20)) {
-        if (!ismimic) {
+        /* only print message if target isn't a concealed mimic */
+        if (M_AP_TYPE(mtmp) == M_AP_NOTHING
+            || M_AP_TYPE(mtmp) == M_AP_MONSTER) {
             if (vis)
                 miss(distant_name(otmp, mshot_xname), mtmp);
             else if (verbose && !g.mtarget)
@@ -353,14 +354,12 @@ ohitmon(
             return 1;
         }
     } else if (otmp->oclass == POTION_CLASS) {
-        if (ismimic)
-            seemimic(mtmp);
         if (vis)
             otmp->dknown = 1;
         /* probably thrown by a monster rather than 'other', but the
            distinction only matters when hitting the hero */
         potionhit(mtmp, otmp, POTHIT_OTHER_THROW);
-        wakeup(mtmp, FALSE, FALSE);
+        wakeup(mtmp, FALSE, TRUE);
         return 1;
     } else {
         damage = dmgval(otmp, mtmp);
@@ -370,9 +369,7 @@ ohitmon(
         if (is_orc(mtmp->data) && is_elf(?magr?))
             damage++;
 #endif
-        if (ismimic)
-            seemimic(mtmp);
-        mtmp->msleeping = 0;
+        wakeup(mtmp, FALSE, TRUE);
         if (vis) {
             if (otmp->otyp == EGG)
                 pline("Splat!  %s is hit with %s egg!", Monnam(mtmp),

--- a/src/mthrowu.c
+++ b/src/mthrowu.c
@@ -360,7 +360,7 @@ ohitmon(
         /* probably thrown by a monster rather than 'other', but the
            distinction only matters when hitting the hero */
         potionhit(mtmp, otmp, POTHIT_OTHER_THROW);
-        wakeup(mtmp, FALSE);
+        wakeup(mtmp, FALSE, FALSE);
         return 1;
     } else {
         damage = dmgval(otmp, mtmp);

--- a/src/muse.c
+++ b/src/muse.c
@@ -1315,7 +1315,7 @@ mbhitm(register struct monst* mtmp, register struct obj* otmp)
     boolean reveal_invis = FALSE, hits_you = (mtmp == &g.youmonst);
 
     if (!hits_you && otmp->otyp != WAN_UNDEAD_TURNING) {
-        wakeup(mtmp, FALSE);
+        wakeup(mtmp, FALSE, TRUE);
     }
     switch (otmp->otyp) {
     case WAN_STRIKING:
@@ -1390,7 +1390,7 @@ mbhitm(register struct monst* mtmp, register struct obj* otmp)
             }
             if (wake) {
                 if (!DEADMONSTER(mtmp))
-                    wakeup(mtmp, FALSE);
+                    wakeup(mtmp, FALSE, TRUE);
                 learnit = g.zap_oseen;
             }
         }

--- a/src/music.c
+++ b/src/music.c
@@ -50,7 +50,7 @@ awaken_monsters(int distance)
         if (DEADMONSTER(mtmp))
             continue;
         if ((distm = distu(mtmp->mx, mtmp->my)) < distance) {
-            wakeup(mtmp, FALSE);
+            wakeup(mtmp, FALSE, FALSE);
             mtmp->mcanmove = 1;
             mtmp->mfrozen = 0;
             /* may scare some monsters -- waiting monsters excluded */
@@ -139,7 +139,7 @@ calm_nymphs(int distance)
             continue;
         if (mtmp->data->mlet == S_NYMPH && mtmp->mcanmove
             && distu(mtmp->mx, mtmp->my) < distance) {
-            wakeup(mtmp, FALSE);
+            wakeup(mtmp, FALSE, FALSE);
             mtmp->mpeaceful = 1;
             mtmp->mavenge = 0;
             mtmp->mstrategy &= ~STRAT_WAITMASK;
@@ -177,7 +177,7 @@ awaken_soldiers(struct monst* bugler  /* monster that played instrument */)
                                  ? distu(mtmp->mx, mtmp->my)
                                  : dist2(bugler->mx, bugler->my, mtmp->mx,
                                          mtmp->my))) < distance) {
-            wakeup(mtmp, FALSE);
+            wakeup(mtmp, FALSE, FALSE);
             mtmp->mcanmove = 1;
             mtmp->mfrozen = 0;
             /* may scare some monsters -- waiting monsters excluded */
@@ -247,7 +247,8 @@ do_earthquake(int force)
     for (x = start_x; x <= end_x; x++)
         for (y = start_y; y <= end_y; y++) {
             if ((mtmp = m_at(x, y)) != 0) {
-                wakeup(mtmp, TRUE); /* peaceful monster will become hostile */
+                /* peaceful monster will become hostile */
+                wakeup(mtmp, TRUE, TRUE);
                 if (mtmp->mundetected) {
                     mtmp->mundetected = 0;
                     newsym(x, y);

--- a/src/music.c
+++ b/src/music.c
@@ -139,7 +139,7 @@ calm_nymphs(int distance)
             continue;
         if (mtmp->data->mlet == S_NYMPH && mtmp->mcanmove
             && distu(mtmp->mx, mtmp->my) < distance) {
-            wakeup(mtmp, FALSE, FALSE);
+            wakeup(mtmp, FALSE, TRUE);
             mtmp->mpeaceful = 1;
             mtmp->mavenge = 0;
             mtmp->mstrategy &= ~STRAT_WAITMASK;

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -1691,7 +1691,7 @@ domindblast(void)
                but in case it is currently peaceful, don't make it hostile
                unless it will survive the psychic blast, otherwise hero
                would avoid the penalty for killing it while peaceful */
-            wakeup(mtmp, (dmg > mtmp->mhp) ? TRUE : FALSE);
+            wakeup(mtmp, (dmg > mtmp->mhp) ? TRUE : FALSE, TRUE);
             You("lock in on %s %s.", s_suffix(mon_nam(mtmp)),
                 u_sen ? "telepathy"
                 : telepathic(mtmp->data) ? "latent telepathy"

--- a/src/potion.c
+++ b/src/potion.c
@@ -1697,10 +1697,7 @@ potionhit(struct monst *mon, struct obj *obj, int how)
             break;
         */
         }
-        /* target might have been killed */
-        if (!DEADMONSTER(mon)) {
-            wakeup(mon, angermon, TRUE);
-        }
+        wakeup(mon, angermon, TRUE);
     }
 
     /* Note: potionbreathe() does its own docall() */

--- a/src/potion.c
+++ b/src/potion.c
@@ -1699,7 +1699,7 @@ potionhit(struct monst *mon, struct obj *obj, int how)
         }
         /* target might have been killed */
         if (!DEADMONSTER(mon)) {
-            wakeup(mon, angermon);
+            wakeup(mon, angermon, TRUE);
         }
     }
 

--- a/src/pray.c
+++ b/src/pray.c
@@ -2169,7 +2169,7 @@ doturn(void)
         if (!mtmp->mpeaceful
             && (is_undead(mtmp->data) || is_vampshifter(mtmp)
                 || (is_demon(mtmp->data) && (u.ulevel > (MAXULEV / 2))))) {
-            wakeup(mtmp, FALSE);
+            wakeup(mtmp, FALSE, FALSE);
             if (Confusion) {
                 if (!once++)
                     pline("Unfortunately, your voice falters.");

--- a/src/pray.c
+++ b/src/pray.c
@@ -2169,7 +2169,7 @@ doturn(void)
         if (!mtmp->mpeaceful
             && (is_undead(mtmp->data) || is_vampshifter(mtmp)
                 || (is_demon(mtmp->data) && (u.ulevel > (MAXULEV / 2))))) {
-            wakeup(mtmp, FALSE, FALSE);
+            wakeup(mtmp, FALSE, TRUE);
             if (Confusion) {
                 if (!once++)
                     pline("Unfortunately, your voice falters.");

--- a/src/priest.c
+++ b/src/priest.c
@@ -810,7 +810,7 @@ angry_priest(void)
     if ((priest = findpriest(temple_occupied(u.urooms))) != 0) {
         struct epri *eprip = EPRI(priest);
 
-        wakeup(priest, FALSE);
+        wakeup(priest, FALSE, TRUE);
         setmangry(priest, FALSE);
         /*
          * If the altar has been destroyed or converted, let the

--- a/src/read.c
+++ b/src/read.c
@@ -1376,7 +1376,7 @@ seffects(struct obj* sobj) /* sobj - scroll, or fake spellbook object for scroll
             if (cansee(mtmp->mx, mtmp->my)) {
                 if (confused || scursed) {
                     mtmp->mflee = mtmp->mfrozen = 0;
-                    wakeup(mtmp, FALSE);
+                    wakeup(mtmp, FALSE, FALSE);
                     mtmp->mcanmove = 1;
                 } else if (!resist(mtmp, sobj->oclass, 0, NOTELL))
                     monflee(mtmp, 0, FALSE, FALSE);
@@ -2062,7 +2062,7 @@ drop_boulder_on_monster(int x, int y, boolean confused, boolean byu)
                 mondied(mtmp);
             }
         } else {
-            wakeup(mtmp, byu);
+            wakeup(mtmp, byu, TRUE);
         }
         wake_nearto(x, y, 4 * 4);
     } else if (u.uswallow && mtmp == u.ustuck) {

--- a/src/trap.c
+++ b/src/trap.c
@@ -4959,7 +4959,7 @@ help_monster_out(
     if (uprob) {
         You("try to grab %s, but cannot get a firm grasp.", mon_nam(mtmp));
         if (mtmp->msleeping) {
-            wakeup(mtmp, FALSE);
+            wakeup(mtmp, FALSE, FALSE);
         }
         return 1;
     }
@@ -4968,7 +4968,7 @@ help_monster_out(
         mon_nam(mtmp));
 
     if (mtmp->msleeping) {
-        wakeup(mtmp, FALSE);
+        wakeup(mtmp, FALSE, FALSE);
     } else if (mtmp->mfrozen && !rn2(mtmp->mfrozen)) {
         /* After such manhandling, perhaps the effect wears off */
         mtmp->mcanmove = 1;
@@ -5400,7 +5400,7 @@ openfallingtrap(
            or if you sense the monster who becomes trapped */
         *noticed = cansee(t->tx, t->ty) || canspotmon(mon);
         /* monster will be angered; mintrap doesn't handle that */
-        wakeup(mon, TRUE);
+        wakeup(mon, TRUE, TRUE);
         ++g.force_mintrap;
         result = (mintrap(mon) != 0);
         --g.force_mintrap;

--- a/src/trap.c
+++ b/src/trap.c
@@ -4959,7 +4959,7 @@ help_monster_out(
     if (uprob) {
         You("try to grab %s, but cannot get a firm grasp.", mon_nam(mtmp));
         if (mtmp->msleeping) {
-            wakeup(mtmp, FALSE, FALSE);
+            wakeup(mtmp, FALSE, TRUE);
         }
         return 1;
     }
@@ -4968,7 +4968,7 @@ help_monster_out(
         mon_nam(mtmp));
 
     if (mtmp->msleeping) {
-        wakeup(mtmp, FALSE, FALSE);
+        wakeup(mtmp, FALSE, TRUE);
     } else if (mtmp->mfrozen && !rn2(mtmp->mfrozen)) {
         /* After such manhandling, perhaps the effect wears off */
         mtmp->mcanmove = 1;

--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -163,7 +163,7 @@ attack_checks(struct monst *mtmp,
          * peacefuls, we're operating as if an attack attempt did occur
          * and the Elbereth behavior is consistent.
          */
-        wakeup(mtmp, TRUE); /* always necessary; also un-mimics mimics */
+        wakeup(mtmp, TRUE, TRUE); /* always necessary; also un-mimics mimics */
         return TRUE;
     }
 
@@ -185,7 +185,7 @@ attack_checks(struct monst *mtmp,
         && !glyph_is_warning(glyph)
         && (hides_under(mtmp->data) || mtmp->data->mlet == S_EEL)) {
         mtmp->mundetected = 0;
-        wakeup(mtmp, FALSE);
+        wakeup(mtmp, FALSE, FALSE);
         newsym(mtmp->mx, mtmp->my);
         if (glyph_is_invisible(glyph)) {
             seemimic(mtmp);
@@ -216,7 +216,7 @@ attack_checks(struct monst *mtmp,
      */
     if ((mtmp->mundetected || M_AP_TYPE(mtmp)) && sensemon(mtmp)) {
         mtmp->mundetected = 0;
-        wakeup(mtmp, TRUE);
+        wakeup(mtmp, TRUE, TRUE);
     }
 
     /* Intelligent chaotic weapons (Stormbringer) want blood */
@@ -334,7 +334,7 @@ find_roll_to_hit(struct monst *mtmp,
         tmp += 2;
 
     if (mtmp->msleeping) {
-        wakeup(mtmp, FALSE);
+        wakeup(mtmp, FALSE, FALSE);
         tmp += 2;
     }
     if (!mtmp->mcanmove) {
@@ -798,7 +798,7 @@ hmon_hitmon(struct monst *mon,
                                               : base_combat_noise);
     }
 
-    wakeup(mon, TRUE);
+    wakeup(mon, TRUE, TRUE);
     if (!obj) { /* attack with bare hands */
         if (noncorporeal(mdat)) {
             tmp = 0;
@@ -1275,7 +1275,7 @@ hmon_hitmon(struct monst *mon,
                         pline(obj->otyp == CREAM_PIE ? "Splat!" : "Splash!");
                         setmangry(mon, TRUE);
                     }
-                    wakeup(mon, TRUE);
+                    wakeup(mon, TRUE, TRUE);
                     {
                         boolean more_than_1 = (obj->quan > 1L);
 
@@ -1640,7 +1640,7 @@ shade_miss(struct monst *magr, struct monst *mdef, struct obj *obj,
             map_invisible(mdef->mx, mdef->my);
     }
     if (!youdef)
-        wakeup(mdef, FALSE);
+        wakeup(mdef, FALSE, TRUE);
     return TRUE;
 }
 
@@ -4694,7 +4694,7 @@ missum(struct monst *mdef, struct attack *mattk, boolean wouldhavehit)
     else
         You("miss it.");
     if (!mdef->msleeping && mdef->mcanmove)
-        wakeup(mdef, TRUE);
+        wakeup(mdef, TRUE, TRUE);
 }
 
 /* attack monster as a monster; returns True if mon survives */
@@ -4823,7 +4823,7 @@ hmonas(struct monst *mon)
                     sum[i] = damageum(mon, mattk, 0);
                     break;
                 }
-                wakeup(mon, TRUE);
+                wakeup(mon, TRUE, TRUE);
                 /* There used to be a bunch of code here to ensure that W_RINGL
                  * and W_RINGR slots got chosen on alternating claw/touch
                  * attacks. There's no such logic for monsters, and if you know
@@ -4910,7 +4910,7 @@ hmonas(struct monst *mon)
             /* automatic if prev two attacks succeed, or if
                already grabbed in a previous attack */
             dhit = 1;
-            wakeup(mon, TRUE);
+            wakeup(mon, TRUE, TRUE);
             specialdmg = special_dmgval(&g.youmonst, mon,
                                         attack_contact_slots(&g.youmonst,
                                                              AT_HUGS),
@@ -4974,7 +4974,7 @@ hmonas(struct monst *mon)
 
         case AT_EXPL: /* automatic hit if next to */
             dhit = -1;
-            wakeup(mon, TRUE);
+            wakeup(mon, TRUE, TRUE);
             You("explode!");
             sum[i] = explum(mon, mattk);
             break;
@@ -4983,7 +4983,7 @@ hmonas(struct monst *mon)
             tmp = find_roll_to_hit(mon, mattk->aatyp, (struct obj *) 0,
                                    &attknum, &armorpenalty);
             if ((dhit = (tmp > rnd(20 + i)))) {
-                wakeup(mon, TRUE);
+                wakeup(mon, TRUE, TRUE);
                 if (noncorporeal(mon->data)) {
                     Your("attempt to surround %s is harmless.", mon_nam(mon));
                 } else {
@@ -5434,7 +5434,7 @@ stumble_onto_mimic(struct monst *mtmp)
     if (what)
         pline(fmt, what);
 
-    wakeup(mtmp, FALSE); /* clears mimicking */
+    wakeup(mtmp, FALSE, TRUE); /* clears mimicking */
     /* if hero is blind, wakeup() won't display the monster even though
        it's no longer concealed */
     if (!canspotmon(mtmp)

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -91,7 +91,7 @@ amulet(void)
         if (DEADMONSTER(mtmp))
             continue;
         if (mtmp->iswiz && mtmp->msleeping && !rn2(40)) {
-            wakeup(mtmp, FALSE);
+            wakeup(mtmp, FALSE, TRUE);
             if (distu(mtmp->mx, mtmp->my) > 2)
                 You(
       "get the creepy feeling that somebody noticed your taking the Amulet.");
@@ -470,7 +470,7 @@ aggravate(void)
         if (in_w_tower != In_W_tower(mtmp->mx, mtmp->my, &u.uz))
             continue;
         mtmp->mstrategy &= ~STRAT_WAITFORU;
-        wakeup(mtmp, FALSE);
+        wakeup(mtmp, FALSE, FALSE);
         if (!mtmp->mcanmove && !rn2(5)) {
             mtmp->mfrozen = 0;
             mtmp->mcanmove = 1;

--- a/src/zap.c
+++ b/src/zap.c
@@ -457,7 +457,7 @@ bhitm(struct monst *mtmp, struct obj *otmp)
     }
     if (wake) {
         if (!DEADMONSTER(mtmp)) {
-            wakeup(mtmp, helpful_gesture ? FALSE : TRUE);
+            wakeup(mtmp, helpful_gesture ? FALSE : TRUE, TRUE);
             m_respond(mtmp);
             if (mtmp->isshk && !*u.ushops)
                 hot_pursuit(mtmp);
@@ -4853,7 +4853,7 @@ zap_over_floor(xchar x, xchar y, int type, boolean *shopdamage,
             You("%s of smoke.", !Blind ? "see a puff" : "smell a whiff");
         }
     if ((mon = m_at(x, y)) != 0) {
-        wakeup(mon, FALSE);
+        wakeup(mon, FALSE, TRUE);
         if (type >= 0 && !g.context.mon_moving) {
             setmangry(mon, TRUE);
             if (mon->ispriest && *in_rooms(mon->mx, mon->my, TEMPLE))


### PR DESCRIPTION
In order to warn the player consistently whenever a sleeping monster is
woken up, xNetHack started using wakeup(mon.c) for all monster waking
(in contrast to vanilla, which just sets mon->msleeping to 0 in a number
of places).  However, the wakeup function also uncloaks mimics, so after
this update, any circumstances that would have previously woken sleeping
monsters (kicking, fighting, blowing a whistle...) now also revealed
mimics in the vicinity.  This made fighting a monster in a shop a lot
riskier, for example, since any number of mimics might abruptly uncloak
and make a beeline towards the hero as soon as the first punch was
thrown.

This commit adds a reveal_hidden parameter to wakeup, which can be used
to specify whether a call to wakeup should reveal a mimic or not, and
uses it to restrict situations which wake mimics to something closer to
the previous norm.