### PR TITLE
Tweaks to pet #looting

### DIFF
--- a/src/pickup.c
+++ b/src/pickup.c
@@ -2524,45 +2524,8 @@ loot_mon(struct monst *mtmp, int *passed_info, boolean *mon_interact)
 {
     int c = -1;
     int timepassed = 0;
-    struct obj *otmp;
     char qbuf[QBUFSZ];
 
-    /* 3.3.1 introduced the ability to remove saddle from a steed.
-     *  *passed_info is set to TRUE if a loot query was given, though it also
-     *  does double duty where it actually holds information from the caller, in
-     *  the case of picking items up from an engulfer.
-     *  *prev_loot is set to TRUE if something was actually acquired in here.
-     */
-    if (mtmp && mtmp != u.usteed && (otmp = which_armor(mtmp, W_SADDLE))) {
-        if (passed_info)
-            *passed_info = 1;
-        Sprintf(qbuf, "Do you want to remove the saddle from %s?",
-                x_monnam(mtmp, ARTICLE_THE, (char *) 0,
-                         SUPPRESS_SADDLE, FALSE));
-        if ((c = yn_function(qbuf, ynqchars, 'n')) == 'y') {
-            if (nolimbs(g.youmonst.data)) {
-                You_cant("do that without limbs."); /* not body_part(HAND) */
-                return 0;
-            }
-            if (otmp->cursed) {
-                You("can't.  The saddle seems to be stuck to %s.",
-                    x_monnam(mtmp, ARTICLE_THE, (char *) 0,
-                             SUPPRESS_SADDLE, FALSE));
-                /* the attempt costs you time */
-                return 1;
-            }
-            extract_from_minvent(mtmp, otmp, TRUE, FALSE);
-            otmp = hold_another_object(otmp, "You drop %s!", doname(otmp),
-                                       (const char *) 0);
-            nhUse(otmp);
-            timepassed = rnd(3); /* note: this doesn't actually take extra time,
-                                    rhack() just treats it like 1 */
-            if (mon_interact)
-                *mon_interact = 1;
-        } else if (c == 'q') {
-            return 0;
-        }
-    }
     /* 3.4.0 introduced ability to pick things up from swallower's stomach */
     if (u.uswallow) {
         int count = passed_info ? *passed_info : 0;

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -2393,7 +2393,8 @@ exchange_objects_with_mon(struct monst *mtmp, boolean taking)
                 continue;
             }
             if (!mindless(mtmp->data) && mtmp_would_ston) {
-                pline("%s refuses to take %s.", Monnam(mtmp), yname(otmp));
+                pline("%s refuses to take %s%s.", Monnam(mtmp),
+                      maxquan < otmp->quan ? "any of " : "", yname(otmp));
                 continue;
             }
             if (otmp == uball || otmp == uchain) {
@@ -2412,7 +2413,8 @@ exchange_objects_with_mon(struct monst *mtmp, boolean taking)
             if (carryamt == 0) {
                 /* note: this includes both "can't carry" and "won't carry", but
                  * doesn't distinguish them */
-                pline("%s can't carry %s.", Monnam(mtmp), yname(otmp));
+                pline("%s can't carry %s%s.", Monnam(mtmp),
+                      maxquan < otmp->quan ? "any of " : "", yname(otmp));
                 /* debatable whether to continue or break here; if the player
                  * overloads the monster with too many items, breaking would be
                  * preferable, but if they just can't take this one otmp for
@@ -2420,8 +2422,10 @@ exchange_objects_with_mon(struct monst *mtmp, boolean taking)
                  * be seen which is the more common scenario. */
                 continue;
             }
-            else if (carryamt < otmp->quan) {
-                maxquan = min(maxquan, carryamt);
+            else if (carryamt < maxquan) {
+                pline("%s can only carry %s of %s.", Monnam(mtmp),
+                      carryamt > 1 ? "some" : "one", yname(otmp));
+                maxquan = carryamt;
             }
             if (maxquan < otmp->quan) {
                 otmp = splitobj(otmp, maxquan);

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -2429,6 +2429,9 @@ exchange_objects_with_mon(struct monst *mtmp, boolean taking)
                 otmp = splitobj(otmp, maxquan);
             }
             pline("You give %s %s.", mon_nam(mtmp), yname(otmp));
+            if (otmp->owornmask) {
+                setnotworn(otmp); /* reset quivered, wielded, etc, status */
+            }
             obj_extract_self(otmp);
             if (add_to_minv(mtmp, otmp)) {
                 otmp = (struct obj *) 0; /* merged with something in minvent */

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -2491,9 +2491,7 @@ exchange_objects_with_mon(struct monst *mtmp, boolean taking)
             if (maxquan < otmp->quan) {
                 otmp = splitobj(otmp, maxquan);
             }
-            else {
-                extract_from_minvent(mtmp, otmp, TRUE, TRUE);
-            }
+            extract_from_minvent(mtmp, otmp, TRUE, TRUE);
             addtobill(otmp, FALSE, FALSE, FALSE);
             otmp = hold_another_object(otmp, "You take, but drop, %s.",
                                          doname(otmp), "You take: ");

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -2405,9 +2405,7 @@ exchange_objects_with_mon(struct monst *mtmp, boolean taking)
                 continue;
             } 
             carryamt = can_carry(mtmp, otmp);
-            if (nohands(mtmp->data) && mtmp->minvent) {
-                /* this isn't a hard and fast rule, but dog_invent in practice
-                 * doesn't let monsters carry around multiple items. */
+            if (nohands(mtmp->data) && droppables(mtmp)) {
                 carryamt = 0;
             }
             if (carryamt == 0) {

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -2396,6 +2396,13 @@ exchange_objects_with_mon(struct monst *mtmp, boolean taking)
                 pline("%s refuses to take %s.", Monnam(mtmp), yname(otmp));
                 continue;
             }
+            if (otmp == uball || otmp == uchain) {
+                /* you can't give a monster your ball & chain, because it
+                 * causes problems elsewhere... */
+                pline("%s shackled to your %s and cannot be given away.",
+                      Tobjnam(otmp, "are"), body_part(LEG));
+                continue;
+            } 
             carryamt = can_carry(mtmp, otmp);
             if (nohands(mtmp->data) && mtmp->minvent) {
                 /* this isn't a hard and fast rule, but dog_invent in practice

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -2378,13 +2378,10 @@ exchange_objects_with_mon(struct monst *mtmp, boolean taking)
 
         /* Clear inapplicable wornmask bits */
         unwornmask &= ~(W_ART | W_ARTI | W_QUIVER);
-        if (!taking || !u.twoweap) {
-            unwornmask &= ~W_SWAPWEP;
-        }
 
         if (!taking) {
             int carryamt;
-            if ((unwornmask & W_WEAPONS) && otmp->cursed) {
+            if (welded(otmp)) {
                 weldmsg(otmp);
                 continue;
             }
@@ -2443,7 +2440,8 @@ exchange_objects_with_mon(struct monst *mtmp, boolean taking)
         }
         else {
             /* cursed weapons, armor, accessories, etc treated the same */
-            if (unwornmask && otmp->cursed) {
+            if ((otmp->cursed && (unwornmask & ~W_WEAPONS)) 
+                || mwelded(otmp)) {
                 pline("%s won't come off!", Yname2(otmp));
                 otmp->bknown = 1;
                 continue;

--- a/src/steal.c
+++ b/src/steal.c
@@ -764,6 +764,7 @@ relobj(
     boolean is_pet) /* If true, pet should keep wielded/worn items */
 {
     struct obj *otmp;
+    struct monst *shkp;
     int omx = mtmp->mx, omy = mtmp->my;
 
     /* vault guard's gold goes away rather than be dropped... */
@@ -777,6 +778,11 @@ relobj(
 
     while ((otmp = (is_pet ? droppables(mtmp) : mtmp->minvent)) != 0) {
         mdrop_obj(mtmp, otmp, is_pet && flags.verbose);
+        if (is_unpaid(otmp) && costly_spot(omx, omy)
+            && (shkp = shop_keeper(*in_rooms(omx, omy, SHOPBASE))) != 0
+            && inhishop(shkp)) {
+            subfrombill(otmp, shkp);
+        }
     }
 
     if (show && cansee(omx, omy))


### PR DESCRIPTION
* Prevent crashes/panics resulting from giving your heavy iron ball to a monster via `#loot` while punished.
* Improve feedback for failure to give a user-specified quantity of items (part of a stack) to a monster, and provide some additional information when the quantity being transferred is reduced because a monster can only carry some of the items in a stack. 
* Stop saddles or other worn items from making it impossible to give something to a handless monster.
* Address the "saddled pony has no saddle" bug (we discussed this bug in `#xnethack` a while back).
* Fix a crash caused by attempting to take part of a stack of items from a monster.
* Subtract the cost of an item from your bill if you give it to a pet and the pet then drops it back on the shop floor, so that you aren't prompted to pay for something that has already been returned to the shop.
* Remove the "do you want to remove the saddle" prompt entirely, since the same thing can be accomplished via "do you want to take something"
* Fix some `impossible`s caused by giving your pet an equipped item (weapon, swapweapon, quivered item...)
* Use rules for determining when cursed weapons and armor are "welded" that are more consistent with those used for other actions