### PR TITLE
Fix: charge for #looting pet in a shop

### DIFF
--- a/src/pickup.c
+++ b/src/pickup.c
@@ -2500,7 +2500,9 @@ exchange_objects_with_mon(struct monst *mtmp, boolean taking)
                 otmp = splitobj(otmp, maxquan);
             }
             extract_from_minvent(mtmp, otmp, TRUE, TRUE);
-            addtobill(otmp, FALSE, FALSE, FALSE);
+            if (*in_rooms(mtmp->mx, mtmp->my, SHOPBASE)) {
+                addtobill(otmp, FALSE, FALSE, FALSE);
+            }
             otmp = hold_another_object(otmp, "You take, but drop, %s.",
                                          doname(otmp), "You take: ");
             transferred++;

--- a/src/shk.c
+++ b/src/shk.c
@@ -1951,9 +1951,10 @@ get_cost_of_shop_item(register struct obj* obj, int* nochrg)
             continue;
         freespot = (top->where == OBJ_FLOOR
                     && x == ESHK(shkp)->shk.x && y == ESHK(shkp)->shk.y);
-        /* no_charge is only set for floor items inside shop proper;
-           items on freespot are implicitly 'no charge' */
-        *nochrg = (top->where == OBJ_FLOOR && (obj->no_charge || freespot));
+        /* no_charge is only set for items on floor or carried by pet inside
+           shop proper; items on freespot are implicitly 'no charge' */
+        *nochrg = ((top->where == OBJ_FLOOR || top->where == OBJ_MINVENT)
+                   && (obj->no_charge || freespot));
 
         if (carried(top) ? (int) obj->unpaid : !*nochrg) {
             long per_unit_cost = get_cost(obj, shkp);


### PR DESCRIPTION
Taking an item from your pet while inside a shop would charge you for
the item, even if it wasn't owned by the shop.  One particularly
illustrative case is a scenario where the hero is standing in the shop
doorway, her pet is in the hallway outside, and the item in question has
never even been inside the shop -- it would still be added to the bill,
and since the hero was already on the shop threshold, a typo could
easily anger the shopkeeper and summon the kops.

Account for the 'free spot(s)' inside a shop (the doorway and the spot
immediately next to it) when considering whether to charge for an item
taken from a pet.  Mark items given to a pet no-charge if they are
already the hero's property, so that giving an item to a pet and
immediately taking it back while standing in a shop, even on a 'costly
square', doesn't cost money.

Also include the '(no charge)' slug for items in a pet's
inventory, since otherwise even uncharged objects would be marked as
'for sale' -- previously this description was only applied to items on
the floor.