### PR TITLE
Add 'readable' Hawaiian shirt designs

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -2183,6 +2183,7 @@ extern long random(void);
 
 extern void learnscroll(struct obj *);
 extern char *tshirt_text(struct obj *, char *);
+extern char *hawaiian_motif(struct obj *, char *);
 extern char *apron_text(struct obj *, char *);
 extern const char *candy_wrapper_text(struct obj *);
 extern void assign_candy_wrapper(struct obj *);

--- a/include/obj.h
+++ b/include/obj.h
@@ -382,10 +382,10 @@ struct obj {
 /* things that can be read */
 #define is_readable(otmp) \
     ((otmp)->otyp == FORTUNE_COOKIE || (otmp)->otyp == T_SHIRT               \
-     || (otmp)->otyp == ALCHEMY_SMOCK || (otmp)->otyp == CREDIT_CARD         \
-     || (otmp)->otyp == CAN_OF_GREASE || (otmp)->otyp == MAGIC_MARKER        \
-     || (otmp)->oclass == COIN_CLASS || (otmp)->oartifact == ART_ORB_OF_FATE \
-     || (otmp)->otyp == CANDY_BAR)
+     || (otmp)->otyp == ALCHEMY_SMOCK || (otmp)->otyp == HAWAIIAN_SHIRT      \
+     || (otmp)->otyp == CREDIT_CARD || (otmp)->otyp == CAN_OF_GREASE         \
+     || (otmp)->otyp == MAGIC_MARKER || (otmp)->oclass == COIN_CLASS         \
+     || (otmp)->oartifact == ART_ORB_OF_FATE || (otmp)->otyp == CANDY_BAR)
 
 /* special stones */
 #define is_graystone(obj)                                 \

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -780,6 +780,10 @@ xname_flags(
             if (*lbl)
                 Sprintf(eos(buf), " labeled \"%s\"", lbl);
             break;
+        case HAWAIIAN_SHIRT:
+            Sprintf(eos(buf), " with %s motif",
+                    an(hawaiian_motif(obj, tmpbuf)));
+            break;
         default:
             break;
         }

--- a/src/read.c
+++ b/src/read.c
@@ -15,6 +15,7 @@
 static boolean learnscrolltyp(short);
 static void cap_spe(struct obj *);
 static char *erode_obj_text(struct obj *, char *);
+static char *hawaiian_design(struct obj *, char *);
 static char *tin_text(struct obj *, char *);
 static int read_ok(struct obj *);
 static void stripspe(struct obj *);
@@ -79,6 +80,66 @@ tshirt_text(struct obj* tshirt, char* buf)
 {
     get_rnd_text(SHIRTFILE, buf, int_hash1(tshirt->o_id), rn2);
     return erode_obj_text(tshirt, buf);
+}
+
+char *
+hawaiian_motif(struct obj* shirt, char* buf)
+{
+    static const char *hawaiian_motifs[] = {
+        /* birds */
+        "flamingo",
+        "parrot",
+        "toucan",
+        "bird of paradise", /* could be a bird or a flower */
+        /* sea creatures */
+        "sea turtle",
+        "tropical fish",
+        "jellyfish",
+        "giant eel",
+        "water nymph",
+        /* plants */
+        "plumeria",
+        "orchid",
+        "hibiscus flower",
+        "palm tree",
+        /* other */
+        "hula dancer",
+        "sailboat",
+        "ukulele",
+    };
+
+    /* tourists' starting shirt always has a consistent o_id, so we need to
+     * introduce additional randomness or else its design will never differ */
+    unsigned motif = shirt->o_id ^ (unsigned) ubirthday;
+
+    Strcpy(buf, hawaiian_motifs[motif % SIZE(hawaiian_motifs)]);
+    return buf;
+}
+
+static char *
+hawaiian_design(struct obj* shirt, char* buf)
+{
+    static const char *hawaiian_bgs[] = {
+        /* solid colors */
+        "purple",
+        "yellow",
+        "red",
+        "blue",
+        "orange",
+        "black",
+        "green",
+        /* adjectives */
+        "abstract",
+        "geometric",
+        "patterned",
+        "naturalistic",
+    };
+
+    unsigned bg = shirt->o_id ^ (unsigned) ~ubirthday;
+    Sprintf(buf, "%s on %s background",
+            makeplural(hawaiian_motif(shirt, buf)),
+            an(hawaiian_bgs[bg % SIZE(hawaiian_bgs)]));
+    return buf;
 }
 
 char *
@@ -309,7 +370,8 @@ doread(void)
                                      "became literate by reading a fortune cookie");
         useup(scroll);
         return 1;
-    } else if (otyp == T_SHIRT || otyp == ALCHEMY_SMOCK) {
+    } else if (otyp == T_SHIRT || otyp == ALCHEMY_SMOCK
+               || otyp == HAWAIIAN_SHIRT) {
         char buf[BUFSZ], *mesg;
         const char *endpunct;
 
@@ -318,28 +380,38 @@ doread(void)
             return 0;
         }
         /* can't read shirt worn under suit (under cloak is ok though) */
-        if (otyp == T_SHIRT && uarm && scroll == uarmu) {
+        if ((otyp == T_SHIRT || otyp == HAWAIIAN_SHIRT) && uarm
+            && scroll == uarmu) {
             pline("%s shirt is obscured by %s%s.",
                   scroll->unpaid ? "That" : "Your", shk_your(buf, uarm),
                   suit_simple_name(uarm));
             return 0;
         }
-        if (!u.uconduct.literate++)
-            livelog_printf(LL_CONDUCT, "became literate by reading %s",
-                           (scroll->otyp == T_SHIRT) ? "a T-shirt" : "an apron");
         /* populate 'buf[]' */
         mesg = (otyp == T_SHIRT) ? tshirt_text(scroll, buf)
-                                 : apron_text(scroll, buf);
-        endpunct = "";
-        if (flags.verbose) {
-            int ln = (int) strlen(mesg);
+                                 : (otyp == HAWAIIAN_SHIRT)
+                                    ? hawaiian_design(scroll, buf)
+                                    : apron_text(scroll, buf);
+        if (otyp == HAWAIIAN_SHIRT) {
+            pline("%s features %s.", flags.verbose ? "The design" : "It",
+                  mesg);
+        } else {
+            if (!u.uconduct.literate++) {
+                livelog_printf(LL_CONDUCT, "became literate by reading %s",
+                               (scroll->otyp == T_SHIRT) ? "a T-shirt"
+                                                         : "an apron");
+            }
+            endpunct = "";
+            if (flags.verbose) {
+                int ln = (int) strlen(mesg);
 
-            /* we will be displaying a sentence; need ending punctuation */
-            if (ln > 0 && !index(".!?", mesg[ln - 1]))
-                endpunct = ".";
-            pline("It reads:");
+                /* we will be displaying a sentence; need ending punctuation */
+                if (ln > 0 && !index(".!?", mesg[ln - 1]))
+                    endpunct = ".";
+                pline("It reads:");
+            }
+            pline("\"%s\"%s", mesg, endpunct);
         }
-        pline("\"%s\"%s", mesg, endpunct);
         return 1;
     } else if ((otyp == DUNCE_CAP || otyp == CORNUTHAUM)
         /* note: "DUNCE" isn't directly connected to tourists but


### PR DESCRIPTION
Functionally similar to reading a T-shirt or apron, but rather than
actual text printed on the shirt being displayed, the design of the
Hawaiian shirt is described: for example, "hula dancers on an orange
background" or "tropical fish on an abstract background".  Much like
T-shirts have their text included in the game-end inventory list ('a
blessed +2 T-shirt with text "foo"'), Hawaiian shirts now have a brief
description of their design appended to their item name under the same
circumstances.

Because 'reading' a Hawaiian shirt doesn't actually involve reading
text, using the 'r' command in this way doesn't break illiterate
conduct.