### PR TITLE
Add traditional Japanese New Year foods

### DIFF
--- a/src/mkobj.c
+++ b/src/mkobj.c
@@ -881,6 +881,14 @@ mksobj(int otyp, boolean init, boolean artif)
                     int holiday = current_holidays();
                     const char* foods[10];
                     int idx = 0;
+                    if (holiday & HOLIDAY_NEW_YEARS
+                        && Role_if(PM_SAMURAI)) {
+                        /* a sampling of traditional Japanese New Year foods
+                           (osechi ryouri) */
+                        foods[idx++] = "bowl of zoni";
+                        foods[idx++] = "datemaki";
+                        foods[idx++] = "kuromame";
+                    }
                     if (holiday & HOLIDAY_VALENTINES_DAY) {
                         foods[idx++] = "box of chocolates";
                         foods[idx++] = "chocolate-covered strawberry";


### PR DESCRIPTION
A number of dishes are traditionally eaten on New Year's Day in Japan;
each has special symbolic meaning (e.g. good health in the upcoming
year). They seem like good candidates for special holiday food.
