### PR TITLE
Fix Windows build AGAIN

### DIFF
--- a/.github/workflows/xnethack-cross-platform-build.yml
+++ b/.github/workflows/xnethack-cross-platform-build.yml
@@ -70,10 +70,11 @@ jobs:
         # This would work to build the tty windows version, though.
         #cp ../sys/winnt/Makefile.gcc ./Makefile
         #mingw32-make LUA_VERSION=$LUA_VERSION install
-    - uses: papeloto/action-zip@v1
+    - uses: thedoctor0/zip-release@master
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        files: binary/
+        type: 'zip'
+        path: binary/
         dest: xnethack_mswindows.zip
     - name: release
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/xnethack-cross-platform-build.yml
+++ b/.github/workflows/xnethack-cross-platform-build.yml
@@ -75,7 +75,7 @@ jobs:
       with:
         type: 'zip'
         path: binary/
-        dest: xnethack_mswindows.zip
+        filename: xnethack_mswindows.zip
     - name: release
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
The GitHub action papeloto/action-zip appears to have disappeared.

Do what K2 did in evilhack commit b6f49ce to fix it.