### PR TITLE
Fix: stack breakage issues

### DIFF
--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -2262,17 +2262,8 @@ breakobj(struct obj *obj,
             }
         }
     }
-    if (!fracture) {
-        /* FIXME: This replicates useup() code but we can't use useup() since
-         * obj isn't necessarily in hero's inventory */
-        if (obj->quan > 1) {
-            obj->quan--;
-            obj->owt = weight(obj);
-        }
-        else {
-            delobj(obj);
-        }
-    }
+    if (!fracture)
+        delobj(obj);
 }
 
 /*
@@ -2370,11 +2361,11 @@ break_glass_obj(struct obj* obj)
             }
             setworn(NULL, unwornmask);
         }
-        update_inventory();
+        obj->ox = u.ux, obj->oy = u.uy;
     }
     else if (mcarried(obj)) { /* monster's item */
+        struct monst *mon = obj->ocarry;
         if (obj->quan == 1L) {
-            struct monst* mon = obj->ocarry;
             mon->misc_worn_check &= ~unwornmask;
             if (unwornmask & W_WEP) {
                 setmnotwielded(mon, obj);
@@ -2386,6 +2377,7 @@ break_glass_obj(struct obj* obj)
             /* shouldn't really be needed but... */
             update_mon_intrinsics(mon, obj, FALSE, FALSE);
         }
+        obj->ox = mon->mx, obj->oy = mon->my;
     }
     else {
         impossible("breaking glass obj not in anyone's inventory?");
@@ -2393,12 +2385,12 @@ break_glass_obj(struct obj* obj)
     }
 
     if (obj->quan == 1L) {
-        obj->owornmask = 0;
-        pline("%s breaks into pieces!", upstart(yname(obj)));
-        obj_extract_self(obj); /* it's being destroyed */
+        obj->owornmask = 0L;
+        pline("%s breaks into pieces!", Yname2(obj));
     }
     else {
         pline("One of %s breaks into pieces!", yname(obj));
+        obj = splitobj(obj, 1L);
     }
     breakobj(obj, obj->ox, obj->oy, your_fault, TRUE);
     if (ucarried)


### PR DESCRIPTION
In order to make it so that a stack of glass weapons would break one at
a time, breakobj was changed in 89c9bb0 to break only a single item per
stack instead of the entire stack at once.  This caused various problems
with other scenarios where stacks might be given to breakobj: breaking
stacks of potions with striking (caused an impossible and contradictory
messages), dropping stacks of potions while levitating (caused a memory
leak as the remaining stack didn't get placed on the ground, but didn't
get freed either), etc.

Instead of breaking stacks item-by-item in breakobj, since the majority
of functions which call it expect it to break an entire stack at once,
restore breakobj to its vanilla behavior and change break_glass_obj to
split the stack if necessary, passing to breakobj only the item which
should be destroyed.  This should preserve the desired 'break one glass
weapon at a time' behavior while fixing the various problems caused by
the breakobj modification.
