### PR TITLE
Fix: destroying bear trap with pick-axe

### DIFF
--- a/src/dig.c
+++ b/src/dig.c
@@ -350,7 +350,7 @@ dig(void)
             } else {
                 You("destroy the bear trap with %s.",
                     yobjnam(uwep, (const char *) 0));
-                deltrap(ttmp);
+                deltrap_with_ammo(ttmp, DELTRAP_DESTROY_AMMO);
                 reset_utrap(TRUE); /* release from trap, maybe Lev or Fly */
             }
             /* we haven't made any progress toward a pit yet */


### PR DESCRIPTION
Digging down with a pick axe on a bear trap you're trapped in will
destroy it.  This produced an impossible, "deleting trap containing
ammo?", because a bear trap uses its ammo field to store the bear trap
item which #untrapping it will produce.  Use deltrap_with_ammo instead,
to remove both the trap and its 'ammo'.
