### PR TITLE
Fix: failure restoring embedded dragon scales

### DIFF
--- a/src/worn.c
+++ b/src/worn.c
@@ -49,7 +49,7 @@ setworn(struct obj *obj, long mask)
     register struct obj *oobj;
     register int p;
 
-    if ((mask & (W_ARM | I_SPECIAL)) == (W_ARM | I_SPECIAL)) {
+    if ((mask & I_SPECIAL) != 0 && (mask & (W_ARM | W_ARMC)) != 0) {
         /* restoring saved game; no properties are conferred via skin */
         uskin = obj;
         /* assert( !uarm ); */


### PR DESCRIPTION
Embedded dragon scales were not restored to 'uskin' when loading a
saved game, because setworn was looking specifically for embedded armor
and disallowed embedded cloaks (or other armor types).  As a result the
scales were left in a sort of half-worn, half-not limbo state, with an
insane wornmask that triggered various sanity checks.
