### PR TITLE
Fix: reversed test in do_symset

### DIFF
--- a/src/symbols.c
+++ b/src/symbols.c
@@ -715,7 +715,7 @@ do_symset(void)
 
         for (sl = g.symset_list; sl; sl = sl->next) {
             /* check restrictions */
-            if (sl->primary)
+            if (sl->rogue)
                 continue;
 #ifndef MAC_GRAPHICS_ENV
             if (sl->handling == H_MAC)
@@ -753,7 +753,7 @@ do_symset(void)
 
         for (sl = g.symset_list; sl; sl = sl->next) {
             /* check restrictions */
-            if (sl->primary)
+            if (sl->rogue)
                 continue;
 #ifndef MAC_GRAPHICS_ENV
             if (sl->handling == H_MAC)


### PR DESCRIPTION
In vanilla these tests are `if (rogueflag ? sl->primary : sl->rogue)`;
in other words, if looking for a Rogue symset, exclude anything marked
as being eligible only for the primary symset, and vice-versa.  When the
Rogue symset was ripped out, apparently the wrong part of the ternary
was preserved, so it was excluding anything marked as primary-only
instead of anything marked rogue-only.  Flip it back around.
