### PR TITLE
Reset cknown when thiefstone changes box contents

### DIFF
--- a/src/dokick.c
+++ b/src/dokick.c
@@ -1793,6 +1793,8 @@ obj_delivery(boolean near_hero)
                             end_burn(otmp, TRUE);
                         add_to_container(cobj, otmp);
                         cobj->owt = weight(cobj);
+                        cobj->cknown = 0; /* contents have changed out of
+                                           * sight of the hero */
                         found_container = TRUE;
                         break;
                     }

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -1758,6 +1758,7 @@ thiefstone_teleport(struct obj* stone, struct obj* obj, boolean dobill)
                         end_burn(obj, TRUE);
                     add_to_container(cobj, obj);
                     cobj->owt = weight(cobj);
+                    cobj->cknown = 0; /* hero hasn't seen new contents */
                     return;
                 }
             }


### PR DESCRIPTION
While playing today, I picked up what turned out to be a thiefstone that
grabbed something from my pack and vanished.  I remembered that there
was a chest across the level, so I farlooked it and could see that the
description changed from "an empty unlocked chest" to "an unlocked chest
containing 2 items".  It seemed odd to me that the hero could detect
that change from across the level.

Change this: when a thiefstone deposits something into its stash
container, reset container->cknown.  There will still be a change
visible in farlook, but this approach is is more consistent with things
that modify container contents outside of direct #looting (e.g. monster
rummaging).
