### PR TITLE
Reveal locked state of adjacent doors in farlook

### DIFF
--- a/src/pager.c
+++ b/src/pager.c
@@ -652,6 +652,14 @@ lookat(int x, int y, char *buf, char *monbuf)
             else
                 Strcpy(buf, "doorway");
             break;
+        case S_vcdoor:
+        case S_hcdoor:
+            if (IS_DOOR(levl[x][y].typ) && next2u(x, y)
+                && door_is_locked(&levl[x][y]))
+                Strcpy(buf, "locked door");
+            else
+                Strcpy(buf, defsyms[symidx].explanation);
+            break;
         case S_cloud:
             Strcpy(buf,
                    Is_airlevel(&u.uz) ? "cloudy area" : "fog/vapor cloud");


### PR DESCRIPTION
The removal of the "(Un)lock it?" prompt for applying an unlocking tool
to a door left players with no way to check whether a door was locked or
not, other than actually opening or unlocking it -- which could leave
them in a sticky situation if the goal of checking its locked status
was to make sure the black dragon on the other side couldn't get out.

Use "locked door" instead of "closed door" for any locked doors in the
immediate vicinity of the hero (akin to the way high altar descriptions
in farlook reveal less or more information depending on the hero's
position), so that this information is available without actually
opening or unlocking the door.  Unlocked doors (as well as mimics
imitating a door, remembered doors which have since been razed, and all
nonadjacent doors) still use "closed door".
