### PR TITLE
Various open air interactions with B&C or boulder

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -489,7 +489,7 @@ extern void set_wounded_legs(long, int);
 extern void heal_legs(int);
 extern void polymorph_sink(void);
 extern void trycall(struct obj *);
-extern void obj_aireffects(struct obj *, boolean);
+extern boolean obj_aireffects(struct obj *, boolean);
 extern void restore_valk_locate(xchar);
 
 /* ### do_name.c ### */

--- a/src/ball.c
+++ b/src/ball.c
@@ -790,7 +790,9 @@ drag_ball(xchar x, xchar y, int *bc_control,
              || !is_pool(uball->ox, uball->oy)
              || levl[uball->ox][uball->oy].typ == POOL))
         || ((t = t_at(uchain->ox, uchain->oy))
-            && (is_pit(t->ttyp) || is_hole(t->ttyp)))) {
+            && (is_pit(t->ttyp) || is_hole(t->ttyp)))
+        || (is_open_air(uchain->ox, uchain->oy)
+            && !is_open_air(uball->ox, uball->oy))) {
         if (Levitation) {
             You_feel("a tug from the iron ball.");
             if (t)
@@ -934,7 +936,7 @@ drop_ball(xchar x, xchar y)
         u.ux0 = u.ux;
         u.uy0 = u.uy;
         if (!Levitation && !MON_AT(x, y) && !u.utrap
-            && (is_pool(x, y)
+            && (is_pool(x, y) || is_open_air(x, y)
                 || ((t = t_at(x, y))
                     && (is_pit(t->ttyp)
                         || is_hole(t->ttyp))))) {

--- a/src/do.c
+++ b/src/do.c
@@ -135,7 +135,6 @@ boulder_hits_pool(struct obj *otmp, int rx, int ry, boolean pushing)
         boolean old_nextboulder = otmp->next_boulder;
         remove_object(otmp);
         otmp->ox = rx, otmp->oy = ry;
-        otmp->next_boulder = 0;
         if (!obj_aireffects(otmp, (pushing || cansee(rx, ry)))) {
             place_object(otmp, ox, oy);
             otmp->next_boulder = old_nextboulder;
@@ -2371,6 +2370,9 @@ boolean
 obj_aireffects(struct obj *obj, boolean talk)
 {
     boolean fell = TRUE;
+    const char *it_falls = Tobjnam(obj, "fall"),
+               *disappears = otense(obj, "disappear");
+
     if ((breaktest(obj) || !rn2(4))
         && !(obj->oartifact || objects[obj->otyp].oc_unique
              || obj == uball || obj == uchain)) {
@@ -2392,8 +2394,7 @@ obj_aireffects(struct obj *obj, boolean talk)
             }
             else if (obj == uball || obj == uchain) {
                 if (obj == uball && !Levitation) {
-                    pline("%s away, dragging you into the abyss.",
-                          Tobjnam(obj, "fall"));
+                    pline("%s away, dragging you into the abyss.", it_falls);
                     /* force hero to fall now if the iron ball hasn't been
                        thrown; throwit(dothrow.c) will move hero and call
                        spoteffects later, so avoid duplication */
@@ -2410,7 +2411,7 @@ obj_aireffects(struct obj *obj, boolean talk)
             if (obj == uball || obj == uchain) {
                 if (obj == uball && !Levitation) {
                     pline("%s away, and %s you down with %s!",
-                          Tobjnam(obj, "fall"), otense(obj, "yank"),
+                          it_falls, otense(obj, "yank"),
                           obj->quan > 1L ? "them" : "it");
                     if (uball != g.thrownobj) {
                         u_aireffects();
@@ -2421,6 +2422,8 @@ obj_aireffects(struct obj *obj, boolean talk)
             }
             else {
                 add_to_migration(obj);
+                if (obj->otyp == BOULDER)
+                    obj->next_boulder = 0;
                 obj->ox = dest.dnum;
                 obj->oy = dest.dlevel;
                 obj->migrateflags = MIGR_RANDOM;
@@ -2428,8 +2431,7 @@ obj_aireffects(struct obj *obj, boolean talk)
         }
     }
     if (fell && talk) {
-        pline("%s away and %s.", Tobjnam(obj, "fall"),
-              otense(obj, "disappear"));
+        pline("%s away and %s.", it_falls, disappears);
     }
     return fell;
 }

--- a/src/do.c
+++ b/src/do.c
@@ -284,6 +284,9 @@ flooreffects(struct obj *obj, int x, int y, const char *verb)
              * through the hole" message, so no need to do it here. */
             res = TRUE;
         }
+    } else if (is_open_air(x, y)) {
+        res = obj_aireffects(obj, cansee(x, y));
+        newsym(x, y);
     } else if (obj->globby) {
         /* Globby things like puddings might stick together */
         while (obj && (otmp = obj_nexto_xy(obj, x, y, TRUE)) != 0) {
@@ -293,10 +296,6 @@ flooreffects(struct obj *obj, int x, int y, const char *verb)
             (void) obj_meld(&obj, &otmp);
         }
         res = (boolean) !obj;
-    }
-    else if (is_open_air(x, y)) {
-        res = obj_aireffects(obj, cansee(x, y));
-        newsym(x, y);
     }
 
     g.bhitpos = save_bhitpos;

--- a/src/do.c
+++ b/src/do.c
@@ -130,6 +130,22 @@ boulder_hits_pool(struct obj *otmp, int rx, int ry, boolean pushing)
             obfree(otmp, (struct obj *) 0);
         return TRUE;
     }
+    else if (is_open_air(rx, ry)) {
+        xchar ox = otmp->ox, oy = otmp->oy;
+        boolean old_nextboulder = otmp->next_boulder;
+        remove_object(otmp);
+        otmp->ox = rx, otmp->oy = ry;
+        otmp->next_boulder = 0;
+        if (!obj_aireffects(otmp, (pushing || cansee(rx, ry)))) {
+            place_object(otmp, ox, oy);
+            otmp->next_boulder = old_nextboulder;
+            return FALSE;
+        }
+        maybe_unhide_at(ox, oy);
+        newsym(ox, oy);
+        newsym(rx, ry);
+        return TRUE;
+    }
     return FALSE;
 }
 
@@ -279,8 +295,7 @@ flooreffects(struct obj *obj, int x, int y, const char *verb)
         res = (boolean) !obj;
     }
     else if (is_open_air(x, y)) {
-        obj_aireffects(obj, cansee(x, y));
-        res = TRUE;
+        res = obj_aireffects(obj, cansee(x, y));
     }
 
     g.bhitpos = save_bhitpos;
@@ -2352,12 +2367,13 @@ heal_legs(
 }
 
 /* Object falls into open air. */
-void
+boolean
 obj_aireffects(struct obj *obj, boolean talk)
 {
     boolean fell = TRUE;
     if ((breaktest(obj) || !rn2(4))
-        && !(obj->oartifact || objects[obj->otyp].oc_unique)) {
+        && !(obj->oartifact || objects[obj->otyp].oc_unique
+             || obj == uball || obj == uchain)) {
         delobj(obj);
         /* it will break, but no messages since it'll be really far away by
          * then */
@@ -2370,24 +2386,52 @@ obj_aireffects(struct obj *obj, boolean talk)
              * weirdly hang there in midair */
             if (objects[obj->otyp].oc_unique) {
                 if (talk)
-                    pline("For some reason, %s hovers in midair.",
-                        the(xname(obj)));
+                    pline("For some reason, %s %s in midair.",
+                          the(xname(obj)), otense(obj, "hover"));
+                fell = FALSE;
+            }
+            else if (obj == uball || obj == uchain) {
+                if (obj == uball && !Levitation) {
+                    pline("%s away, dragging you into the abyss.",
+                          Tobjnam(obj, "fall"));
+                    /* force hero to fall now if the iron ball hasn't been
+                       thrown; throwit(dothrow.c) will move hero and call
+                       spoteffects later, so avoid duplication */
+                    if (uball != g.thrownobj) {
+                        u_aireffects();
+                    }
+                }
                 fell = FALSE;
             }
             else
                 delobj(obj);
         }
         else {
-            add_to_migration(obj);
-            obj->ox = dest.dnum;
-            obj->oy = dest.dlevel;
-            obj->migrateflags = MIGR_RANDOM;
+            if (obj == uball || obj == uchain) {
+                if (obj == uball && !Levitation) {
+                    pline("%s away, and %s you down with %s!",
+                          Tobjnam(obj, "fall"), otense(obj, "yank"),
+                          obj->quan > 1L ? "them" : "it");
+                    if (uball != g.thrownobj) {
+                        u_aireffects();
+                    }
+                }
+                fell = FALSE; /* either doesn't fall at all (if levitating),
+                               * or doesn't fall by itself */
+            }
+            else {
+                add_to_migration(obj);
+                obj->ox = dest.dnum;
+                obj->oy = dest.dlevel;
+                obj->migrateflags = MIGR_RANDOM;
+            }
         }
     }
     if (fell && talk) {
-        pline("%s %s away and %s.", The(xname(obj)),
-                otense(obj, "fall"), otense(obj, "disappear"));
+        pline("%s away and %s.", Tobjnam(obj, "fall"),
+              otense(obj, "disappear"));
     }
+    return fell;
 }
 
 /* Restore the Valkyrie locate level after the nemesis is killed;

--- a/src/do.c
+++ b/src/do.c
@@ -296,6 +296,7 @@ flooreffects(struct obj *obj, int x, int y, const char *verb)
     }
     else if (is_open_air(x, y)) {
         res = obj_aireffects(obj, cansee(x, y));
+        newsym(x, y);
     }
 
     g.bhitpos = save_bhitpos;

--- a/src/hack.c
+++ b/src/hack.c
@@ -2862,7 +2862,6 @@ u_aireffects(void)
             You("fall to your death again.");
             done(DIED);
         }
-        return;
     }
     else {
         You("plummet into the depths...");

--- a/src/hack.c
+++ b/src/hack.c
@@ -2917,7 +2917,10 @@ spoteffects(boolean pick)
     if (pooleffects(TRUE))
         goto spotdone;
 
-    if (is_open_air(u.ux, u.uy) && !Levitation && !Flying
+    if (is_open_air(u.ux, u.uy) && !Levitation
+        /* normally won't fall if flying, unless iron ball is pulling you */
+        && !(Flying && !(Punished && !carried(uball)
+                         && is_open_air(uball->ox, uball->oy)))
         && !(u.usteed && !grounded(u.usteed->data))) {
         u_aireffects();
         goto spotdone;

--- a/src/mon.c
+++ b/src/mon.c
@@ -5513,7 +5513,7 @@ mon_aireffects(struct monst *mtmp)
         for (otmp = mtmp->minvent; otmp; otmp = nobj) {
             nobj = otmp->nobj;
             obj_extract_self(otmp);
-            obj_aireffects(otmp, FALSE);
+            (void) obj_aireffects(otmp, FALSE);
         }
         /* No corpse is dropped here, because it would give a message about the
          * corpse falling away and disappearing which doesn't make any sense.

--- a/src/read.c
+++ b/src/read.c
@@ -3079,7 +3079,8 @@ punish(struct obj* sobj)
 void
 unpunish(void)
 {
-    struct obj *savechain = uchain;
+    struct obj *savechain = uchain,
+               *saveball = uball;
 
     /* chain goes away */
     obj_extract_self(uchain);
@@ -3089,6 +3090,17 @@ unpunish(void)
     dealloc_obj(savechain);
     /* the chain is gone but the no longer attached ball persists */
     setworn((struct obj *) 0, W_BALL); /* sets 'uball' to Null */
+    if (saveball->where == OBJ_FLOOR
+        && is_open_air(saveball->ox, saveball->oy)) {
+        /* pick up the ball and drop it, so it can fall through the air */
+        obj_extract_self(saveball);
+        if (!flooreffects(saveball, saveball->ox, saveball->oy, "drop")) {
+            place_object(saveball, saveball->ox, saveball->oy);
+        } else {
+            maybe_unhide_at(saveball->ox, saveball->oy);
+            newsym(saveball->ox, saveball->oy);
+        }
+    }
 }
 
 /* Prompt the player to create a stinking cloud and then create it if they give

--- a/src/trap.c
+++ b/src/trap.c
@@ -3683,7 +3683,7 @@ float_down(
     }
 
     if (Punished && !carried(uball)
-        && (is_pool(uball->ox, uball->oy)
+        && (is_pool(uball->ox, uball->oy) || is_open_air(uball->ox, uball->oy)
             || ((trap = t_at(uball->ox, uball->oy))
                 && (is_pit(trap->ttyp) || is_hole(trap->ttyp))))) {
         u.ux0 = u.ux;


### PR DESCRIPTION
Throwing your attached iron ball into open air/a chasm improperly
moved it to another level without unpunishing you, it could levitate if
dragged over open air, a boulder wouldn't fall if pushed over open air,
obj_aireffects could delete uball, reading a scroll of punishment while
flying over a chasm could cause a panic, etc...

This is my attempt to fix the issues I am aware of, but I'm sure there
are more problems with open air lurking around that nobody has noticed
yet... This definitely merits some more rigorous testing, e.g. from
always-punished fuzzer set loose in the new Valkyrie quest.