### PR TITLE
Fix: HP not restored when lifesaved

### DIFF
--- a/src/end.c
+++ b/src/end.c
@@ -1002,6 +1002,7 @@ savelife(int how)
         u.ulevel = 1;
     uhpmin = minuhpmax(10);
     if (u.uhpmax < uhpmin)
+        setuhpmax(uhpmin);
     u.uhp = min(u.uhpmax, 100);
     if (Upolyd) /* Unchanging, or death which bypasses losing hit points */
         u.mh = min(u.mhmax, 100);


### PR DESCRIPTION
I'm not sure how this happened (maybe a bad merge of vanilla commit
d53c1a7, since that modified the missing line?) but at some point this
code from savelife(end.c):

| if (u.uhpmax < uhpmin)
|     u.uhpmax = uhpmin;
| u.uhp = min(u.uhpmax, 100);

Lost the middle line, turning it into:

| if (u.uhpmax < uhpmin)
| u.uhp = min(u.uhpmax, 100);

In other words, HP wasn't restored unless your max HP was lower than the
minimum max HP for your level.  Presumably this was a mistake since it
meant you could be brought to 0 HP, burn an amulet of life-saving, and
still have 0 HP afterwards.
