### PR TITLE
Drawbridge jams

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -320,11 +320,13 @@ extern boolean is_open_air(int, int);
 extern schar db_under_typ(int);
 extern int is_drawbridge_wall(int, int);
 extern boolean is_db_wall(int, int);
+extern boolean is_jammed_db(int, int);
 extern boolean find_drawbridge(int *, int *);
 extern boolean create_drawbridge(int, int, int, boolean);
 extern void open_drawbridge(int, int);
 extern void close_drawbridge(int, int);
 extern void destroy_drawbridge(int, int);
+extern int unjam_drawbridge(int, int);
 
 /* ### decl.c ### */
 

--- a/include/rm.h
+++ b/include/rm.h
@@ -192,20 +192,22 @@ enum door_states {
 /*
  * The four directions for a DrawBridge.
  */
-#define DB_NORTH 0
-#define DB_SOUTH 1
-#define DB_EAST 2
-#define DB_WEST 3
-#define DB_DIR 3 /* mask for direction */
+#define DB_NORTH 0x0
+#define DB_SOUTH 0x1
+#define DB_EAST  0x2
+#define DB_WEST  0x3
+#define DB_DIR   0x3 /* mask for direction */
 
 /*
  * What's under a drawbridge.
  */
-#define DB_MOAT 0
-#define DB_LAVA 4
-#define DB_ICE 8
-#define DB_FLOOR 16
-#define DB_UNDER 28 /* mask for underneath */
+#define DB_MOAT  0x0
+#define DB_LAVA  0x4
+#define DB_ICE   0x8
+#define DB_FLOOR 0xc
+#define DB_UNDER 0xc /* mask for underneath */
+
+#define DB_JAM   0x10
 
 /*
  * Wall information.  Nondiggable also applies to iron bars.

--- a/src/music.c
+++ b/src/music.c
@@ -757,8 +757,7 @@ do_play_instrument(struct obj* instr)
                             u.uevent.uheard_tune = 2;
                             record_achievement(ACH_TUNE);
                             if (levl[x][y].typ == DRAWBRIDGE_DOWN) {
-                                boolean jammed =
-                                    (levl[x][y].drawbridgemask & DB_JAM) != 0;
+                                boolean jammed = is_jammed_db(x, y);
                                 if (!rn2(5) || jammed) {
                                     pline("The mechanism seems to %s jammed.",
                                           jammed ? "be" : "get");

--- a/src/music.c
+++ b/src/music.c
@@ -757,14 +757,13 @@ do_play_instrument(struct obj* instr)
                             u.uevent.uheard_tune = 2;
                             record_achievement(ACH_TUNE);
                             if (levl[x][y].typ == DRAWBRIDGE_DOWN) {
-                                if (!rn2(5)) {
-                                    /* Future improvement: if flags is ever
-                                     * expanded beyond 5 bits, could set a bit
-                                     * here to make the mechanism continue to be
-                                     * stuck until some condition is met, such
-                                     * as opening/closing magic used on it */
-                                    pline("The mechanism seems to get jammed.");
+                                boolean jammed =
+                                    (levl[x][y].drawbridgemask & DB_JAM) != 0;
+                                if (!rn2(5) || jammed) {
+                                    pline("The mechanism seems to %s jammed.",
+                                          jammed ? "be" : "get");
                                     pline("It won't close.");
+                                    levl[x][y].drawbridgemask |= DB_JAM;
                                     return ECMD_TIME;
                                 }
                                 close_drawbridge(x, y);

--- a/src/trap.c
+++ b/src/trap.c
@@ -5449,7 +5449,10 @@ untrap(
                     return 0;
                 }
             }
-        } /* end if */
+        }
+        else if (is_jammed_db(x, y)) {
+            return unjam_drawbridge(x, y);
+        }
 
         if (boxcnt) {
             /* 3.7: this used to allow searching for traps on multiple


### PR DESCRIPTION
 Mentioned in 1654735 and a comment in do_play_instrument(music.c) as
 something which would be a nice future improvement if there were more
 bits available in flags/drawbridgemask.  Turns out the DB_UNDER states 
 are all mutually exclusive and never overlap, so a bit for the jam can 
 be saved by rearranging those.  An attempt at implementing this.
