### PR TITLE
Fix: Valkyrie quest not marked completed

### DIFF
--- a/src/quest.c
+++ b/src/quest.c
@@ -272,6 +272,8 @@ leader_sees_qarti(struct obj *obj) /* quest artifact; possibly null if carrying
            quest artifact */
         fully_identify_obj(obj);
         update_inventory();
+    } else if (!arti_fulfills_quest()) {
+        u.uevent.qcompleted = 1;
     }
 }
 


### PR DESCRIPTION
The Valkyrie quest doesn't require handing over an object, so the quest
could be finished without being marked as completed (causing the "pleas
for help" message to be repeated every time the hero entered the quest
portal level).
