### PR TITLE
Fix: changing and/or gibberish T-shirt messages

### DIFF
--- a/src/do_name.c
+++ b/src/do_name.c
@@ -2383,7 +2383,9 @@ bogusmon(char *buf, char *code, int which)
     if (code)
         *code = '\0';
     /* might fail (return empty buf[]) if the file isn't available */
-    get_rnd_text(BOGUSMONFILE, buf, which, rn2_on_display_rng, MD_PAD_BOGONS);
+    get_rnd_text(BOGUSMONFILE, buf, which,
+                 (which > 0 ? (int (*)(int)) 0 : rn2_on_display_rng),
+                 MD_PAD_BOGONS);
     if (!*mnam) {
         Strcpy(buf, "bogon");
     } else if (index(bogon_codes, *mnam)) { /* strip prefix if present */

--- a/src/read.c
+++ b/src/read.c
@@ -100,7 +100,8 @@ erode_obj_text(struct obj* otmp, char* buf)
 char *
 tshirt_text(struct obj* tshirt, char* buf)
 {
-    get_rnd_text(SHIRTFILE, buf, int_hash1(tshirt->o_id), rn2, MD_PAD_RUMORS);
+    get_rnd_text(SHIRTFILE, buf, int_hash1(tshirt->o_id), (int (*)(int)) 0,
+                 MD_PAD_RUMORS);
     return erode_obj_text(tshirt, buf);
 }
 


### PR DESCRIPTION
Trying to use get_rnd_text deterministically for T-shirt or bogusmon tin
text was not working; instead, it was cycling through multiple adjacent
messages, including often one which was gibberish (because it was the
second half of a line, xcrypted).  For example, one shirt I encountered
cycled through the messages "Hello, I'm War!", "Got Newt?", and
"\YSGN\YSGN\YS" when read repeatedly.  I assume this issue may have been
caused by the line padding, use of which was expanded recently-ish to
included text data files other than rumors.

Modify the relevant functions so that they can work deterministically
again.  At least, hopefully... I'm not certain whether my understanding
of the problem or the fix is 100% correct.  It appears to work but could
use some careful review.
