### PR TITLE
Fix: air bubble on Water described as "cliff"

### DIFF
--- a/src/hack.c
+++ b/src/hack.c
@@ -1704,7 +1704,7 @@ static boolean
 air_move_danger(xchar x, xchar y)
 {
     if (u_simple_floortyp(x, y) != u_simple_floortyp(u.ux, u.uy)
-        && IS_AIR(levl[x][y].typ)
+        && is_open_air(x, y)
         && !Stunned && !Confusion && levl[x][y].seenv) {
         if (g.context.nopick) {
             /* moving with 'm' */


### PR DESCRIPTION
The function used IS_AIR rather than is_open_air, so classified the water-to-air transition on the plane of water as a "cliff".
