### PR TITLE
Qt: change "NetHack" to "xNetHack" in labels

### DIFF
--- a/win/Qt/qt_main.cpp
+++ b/win/Qt/qt_main.cpp
@@ -465,7 +465,7 @@ aboutMsg()
     (void) strsubst(vbuf, " - ", "\n- ");
     QString msg = QString::asprintf(
         // format
-        "NetHack-Qt is a version of NetHack built using" // no newline
+        "xNetHack-Qt is a version of xNetHack built using" // no newline
 #ifdef KDE
         " KDE and"                                       // ditto
 #endif
@@ -487,7 +487,7 @@ aboutMsg()
         "Qt:\n     http://www.troll.no/\n"      // obsolete
 #endif
         "Lua:\n     https://lua.org/\n"
-        "NetHack:\n     %s\n", // DEVTEAM_URL
+        "xNetHack:\n     %s\n", // DEVTEAM_URL
         // arguments
 #ifdef QT_VERSION_MAJOR
         QT_VERSION_MAJOR,
@@ -537,7 +537,7 @@ NetHackQtMainWindow::NetHackQtMainWindow(NetHackQtKeyBuffer& ks) :
     addToolBar(toolbar);
     menubar = menuBar();
 
-    setWindowTitle("NetHack-Qt");
+    setWindowTitle("xNetHack-Qt");
     setWindowIcon(QIcon(QPixmap(qt_compact_mode ? nh_icon_small : nh_icon)));
 
 #ifdef MACOS
@@ -710,23 +710,23 @@ NetHackQtMainWindow::NetHackQtMainWindow(NetHackQtKeyBuffer& ks) :
        nethack's #quit command with "really quit?" prompt, this quit--with
        Command+q as shortcut--pops up a dialog to choose between quit or
        cancel-and-resume-playing */
-    actn = game->addAction("Quit NetHack-Qt", this, SLOT(doQuit(bool)));
+    actn = game->addAction("Quit xNetHack-Qt", this, SLOT(doQuit(bool)));
     actn->setMenuRole(QWidgetAction::QuitRole);
 #endif
 
-    actn = help->addAction("About NetHack-Qt", this, SLOT(doAbout(bool)));
+    actn = help->addAction("About xNetHack-Qt", this, SLOT(doAbout(bool)));
 #ifdef MACOS
     actn->setMenuRole(QWidgetAction::AboutRole);
     /* for OSX, the preceding "About" went into the application menu;
        now add another duplicate one to the Help dropdown menu */
-    actn = help->addAction("About NetHack-Qt", this, SLOT(doAbout(bool)));
+    actn = help->addAction("About xNetHack-Qt", this, SLOT(doAbout(bool)));
     actn->setMenuRole(QWidgetAction::NoRole);
 #else
     nhUse(actn);
 #endif
     help->addSeparator();
 
-    //help->addAction("NetHack Guidebook", this, SLOT(doGuidebook(bool)));
+    //help->addAction("xNetHack Guidebook", this, SLOT(doGuidebook(bool)));
     //help->addSeparator();
 
     for (int i = 0; item[i].menu; ++i) {
@@ -1015,7 +1015,7 @@ void NetHackQtMainWindow::doQtSettings(bool)
 
 void NetHackQtMainWindow::doAbout(bool)
 {
-    QMessageBox::about(this, "About NetHack-Qt", aboutMsg());
+    QMessageBox::about(this, "About xNetHack-Qt", aboutMsg());
 }
 
 // on OSX, "quit nethack" has been selected in the application menu or
@@ -1029,7 +1029,7 @@ void NetHackQtMainWindow::doQuit(bool)
     // nethack's #quit command itself) but this routine is unconditional
     // in case someone wants to change that
 #ifdef MACOS
-    QString info = QString::asprintf("This will end your NetHack session.%s",
+    QString info = QString::asprintf("This will end your xNetHack session.%s",
                  !g.program_state.something_worth_saving ? ""
                  : "\n(Cancel quitting and use the Save command"
                    "\nto save your current game.)");
@@ -1038,7 +1038,7 @@ void NetHackQtMainWindow::doQuit(bool)
        the second choice (Quit) is the action for <return> or <space>;
        <escape> leaves the popup waiting for some other response;
        the &<char> settings for Alt+<char> shortcuts don't work on OSX */
-    int act = QMessageBox::information(this, "NetHack", info,
+    int act = QMessageBox::information(this, "xNetHack", info,
                                        "&Cancel and return to game",
                                        "&Quit without saving",
                                        0, 1);
@@ -1381,8 +1381,8 @@ void NetHackQtMainWindow::closeEvent(QCloseEvent *e UNUSED)
         /* this used to offer "Save" and "Cancel"
            but cancel (ignoring the close attempt) won't work
            if user has clicked on the window's Close button */
-	int act = QMessageBox::information(this, "NetHack",
-                              "This will end your NetHack session.",
+	int act = QMessageBox::information(this, "xNetHack",
+                              "This will end your xNetHack session.",
                               "&Save and exit", "&Quit without saving", 0, 1);
 	switch (act) {
         case 0:

--- a/win/Qt/qt_plsel.cpp
+++ b/win/Qt/qt_plsel.cpp
@@ -74,8 +74,7 @@ void centerOnMain( QWidget* w );
 
 // hack: padded with blank lines by inserting breaks above and below in
 // order to force window to be tall enough to show all the roles at once
-static const char nh_attribution[] = "<br><center><big>NetHack %1</big>"
-        "<br><small>by the NetHack DevTeam</small></center><br>";
+static const char nh_attribution[] = "<br><center><big>xNetHack %1</big>";
 
 //
 // None of these extra classes seem to be used except for NhPSListView. [pr]

--- a/win/Qt/qt_set.cpp
+++ b/win/Qt/qt_set.cpp
@@ -171,7 +171,7 @@ NetHackQtSettings::NetHackQtSettings() :
     int row = 0; // used like X11-style XtSetArg(), ++argc
      QGridLayout *grid = new QGridLayout(this);
     // dialog box label, spans first two rows and all three columns
-    QLabel *settings_label = new QLabel("Qt NetHack Settings\n", this);
+    QLabel *settings_label = new QLabel("Qt xNetHack Settings\n", this);
     grid->addWidget(settings_label, row, 0, 2, 3), row += 2; // uses extra row
     settings_label->setAlignment(Qt::AlignHCenter | Qt::AlignTop);
 

--- a/win/Qt/qt_svsel.cpp
+++ b/win/Qt/qt_svsel.cpp
@@ -66,7 +66,7 @@ NetHackQtSavedGameSelector::NetHackQtSavedGameSelector(const char** saved) :
     QHBoxLayout* hb;
 
     char cvers[BUFSZ];
-    QString qvers = QString("NetHack ") + QString(version_string(cvers, sizeof cvers));
+    QString qvers = QString("xNetHack ") + QString(version_string(cvers, sizeof cvers));
     QLabel *vers = new QLabel(qvers, this);
     vers->setAlignment(Qt::AlignCenter);
     vbl->addWidget(vers);
@@ -75,11 +75,6 @@ NetHackQtSavedGameSelector::NetHackQtSavedGameSelector(const char** saved) :
     logo->setAlignment(Qt::AlignCenter);
     logo->setPixmap(QPixmap("nhsplash.xpm"));
     vbl->addWidget(logo);
-
-    QLabel *attr = new QLabel("by the NetHack DevTeam", this);
-    attr->setAlignment(Qt::AlignCenter);
-    vbl->addWidget(attr);
-    vbl->addStretch(2);
 
     /* With Qt5, this next line triggers a complaint to stderr:
 QLayout: Attempting to add QLayout "" to QDialog "", which already has a layout


### PR DESCRIPTION
This commit removes the 'by the NetHack DevTeam' byline from the
new/load game popups, rather than replacing it with a different credit.
