### PR TITLE
Incorporate object materials into glyphmap

### DIFF
--- a/include/display.h
+++ b/include/display.h
@@ -703,7 +703,8 @@ enum glyph_offsets {
 
 /* Not affected by hallucination.  Gives a generic body for CORPSE */
 /* MRKR: ...and the generic statue */
-#define objnum_to_glyph(onum) ((int) (onum) + GLYPH_OBJ_OFF)
+#define objnum_to_glyph(onum) \
+    (((int) (onum) * NUM_MATERIAL_TYPES) + GLYPH_OBJ_OFF)
 #define monnum_to_glyph(mnum,gnd) \
     ((int) (mnum) + (((gnd) == MALE) ? GLYPH_MON_MALE_OFF       \
                                      : GLYPH_MON_FEM_OFF))

--- a/include/objclass.h
+++ b/include/objclass.h
@@ -10,6 +10,7 @@
    (liquid potion inside glass bottle, metal arrowhead on wooden shaft)
    and object definitions only specify one type on a best-fit basis */
 enum obj_material_types {
+    NO_MATERIAL =  0,
     LIQUID      =  1, /* currently only for venom */
     WAX         =  2,
     VEGGY       =  3, /* foodstuffs */

--- a/src/display.c
+++ b/src/display.c
@@ -2387,16 +2387,15 @@ map_glyphinfo(
 #ifdef TEXTCOLOR
     /* isok is used because this is sometimes called with 0,0 */
     if (iflags.use_color && isok(x, y)) {
+        if (On_stairs(x,y))
+            glyphinfo->gm.glyphflags |= MG_STAIRS;
         /* object or statue, which might be made of a non-default material or on
          * stairs */
-        if (glyph_is_statue(glyph) || glyph_is_normal_object(glyph)
-            || glyph_is_body(glyph)) {
+        if (glyph_is_statue(glyph) || glyph_is_body(glyph)) {
             struct obj *otmp = vobj_at(x, y);
             if (otmp) {
                 if (otmp && otmp->material != objects[otmp->otyp].oc_material)
                     glyphinfo->gm.sym.color = materialclr[otmp->material];
-                if (On_stairs(x,y))
-                    glyphinfo->gm.glyphflags |= MG_STAIRS;
             }
             /* !otmp is not actually impossible, because this is called from
              * tmp_at(), in which an object is flying through the air above
@@ -2525,6 +2524,7 @@ int wallcolors[sokoban_walls + 1] = {
 #define zap_color(n) color = iflags.use_color ? zapcolors[n] : NO_COLOR
 #define cmap_color(n) color = iflags.use_color ? defsyms[n].color : NO_COLOR
 #define obj_color(n) color = iflags.use_color ? objects[n].oc_color : NO_COLOR
+#define material_color(n) color = iflags.use_color ? materialclr[n]: NO_COLOR
 #define mon_color(n) \
     color = iflags.use_color \
         ? g.monstercolors[n] != MONSTERCOLOR_DEFAULT \
@@ -2547,6 +2547,7 @@ int wallcolors[sokoban_walls + 1] = {
 #define zap_color(n)
 #define cmap_color(n)
 #define obj_color(n)
+#define material_color(n)
 #define mon_color(n)
 #define invis_color(n)
 #define pet_color(c)
@@ -2630,10 +2631,15 @@ reset_glyphmap(enum glyphmap_change_triggers trigger)
             mon_color(offset);
             gmap->glyphflags |= (MG_CORPSE | MG_OBJPILE);
         } else if ((offset = (glyph - GLYPH_OBJ_PILETOP_OFF)) >= 0) {
-            gmap->sym.symidx = objects[offset].oc_class + SYM_OFF_O;
-            if (offset == BOULDER)
+            int mat = (offset % NUM_MATERIAL_TYPES),
+                oid = (offset / NUM_MATERIAL_TYPES);
+            gmap->sym.symidx = objects[oid].oc_class + SYM_OFF_O;
+            if (oid == BOULDER)
                 gmap->sym.symidx = SYM_BOULDER + SYM_OFF_X;
-            obj_color(offset);
+            if (mat == objects[oid].oc_material || mat == NO_MATERIAL)
+                obj_color(oid);
+            else
+                material_color(mat);
             gmap->glyphflags |= MG_OBJPILE;
         } else if ((offset = (glyph - GLYPH_STATUE_FEM_OFF)) >= 0) {
             gmap->sym.symidx = mons[offset].mlet + SYM_OFF_M;
@@ -2749,10 +2755,15 @@ reset_glyphmap(enum glyphmap_change_triggers trigger)
             gmap->sym.symidx = SYM_OFF_P;
             cmap_color(S_stone);
         } else if ((offset = (glyph - GLYPH_OBJ_OFF)) >= 0) {
-            gmap->sym.symidx = objects[offset].oc_class + SYM_OFF_O;
-            if (offset == BOULDER)
+            int mat = (offset % NUM_MATERIAL_TYPES),
+                oid = (offset / NUM_MATERIAL_TYPES);
+            gmap->sym.symidx = objects[oid].oc_class + SYM_OFF_O;
+            if (oid == BOULDER)
                 gmap->sym.symidx = SYM_BOULDER + SYM_OFF_X;
-            obj_color(offset);
+            if (mat == objects[oid].oc_material || mat == NO_MATERIAL)
+                obj_color(oid);
+            else
+                material_color(mat);
         } else if ((offset = (glyph - GLYPH_RIDDEN_FEM_OFF)) >= 0) {
             gmap->sym.symidx = mons[offset].mlet + SYM_OFF_M;
             mon_color(offset);

--- a/src/display.c
+++ b/src/display.c
@@ -2387,39 +2387,10 @@ map_glyphinfo(
 #ifdef TEXTCOLOR
     /* isok is used because this is sometimes called with 0,0 */
     if (iflags.use_color && isok(x, y)) {
-        if (On_stairs(x,y))
+        /* object or statue, which might be made of a non-default material or
+         * on stairs */
+        if (glyph_is_object(glyph) && On_stairs(x,y))
             glyphinfo->gm.glyphflags |= MG_STAIRS;
-        /* object or statue, which might be made of a non-default material or on
-         * stairs */
-        if (glyph_is_statue(glyph) || glyph_is_body(glyph)) {
-            struct obj *otmp = vobj_at(x, y);
-            if (otmp) {
-                if (otmp && otmp->material != objects[otmp->otyp].oc_material)
-                    glyphinfo->gm.sym.color = materialclr[otmp->material];
-            }
-            /* !otmp is not actually impossible, because this is called from
-             * tmp_at(), in which an object is flying through the air above
-             * ground where there's usually no object.
-             * There is no single unified way to get the object that happens to
-             * be flying through the air. g.thrownobj and g.kickedobj are only
-             * set in a small number of cases involving flying objects, and it's
-             * possible that by comprehensively tracking them in all cases,
-             * !otmp would actually be an impossible case.
-             * This causes the following bugs (both of which were present before
-             * commit 1f6c1d0):
-             *   1. Flying objects' materials don't normally render. The object
-             *      is shown as the base glyph no matter its material.
-             *   2. If a flying object passes over an object of a material
-             *      that's not its base, it will briefly render as that material
-             *      (since we have only x, y, and glyph here and vobj_at() can't
-             *      tell that it's actually a flying object being mapped.)
-             * Another reason !otmp is not actually impossible is that the
-             * object could have been moved while out of sight.
-            else
-                impossible("no visible object at (%d, %d)?",
-                           x, y);
-            */
-        }
         /* iron door
          * (only check closed door defsym range, not S_ndoor) */
         else if (gmap->sym.symidx >= S_vodoor + SYM_OFF_P
@@ -2619,12 +2590,22 @@ reset_glyphmap(enum glyphmap_change_triggers trigger)
             color = NO_COLOR;
             gmap->glyphflags |= MG_UNEXPL;
         } else if ((offset = (glyph - GLYPH_STATUE_FEM_PILETOP_OFF)) >= 0) {
-            gmap->sym.symidx = mons[offset].mlet + SYM_OFF_M;
-            obj_color(STATUE);
+            int mat = (offset % NUM_MATERIAL_TYPES),
+                mid = (offset / NUM_MATERIAL_TYPES);
+            gmap->sym.symidx = mons[mid].mlet + SYM_OFF_M;
+            if (mat == objects[STATUE].oc_material || mat == NO_MATERIAL)
+                obj_color(STATUE);
+            else
+                material_color(mat);
             gmap->glyphflags |= (MG_STATUE | MG_FEMALE | MG_OBJPILE);
         } else if ((offset = (glyph - GLYPH_STATUE_MALE_PILETOP_OFF)) >= 0) {
-            gmap->sym.symidx = mons[offset].mlet + SYM_OFF_M;
-            obj_color(STATUE);
+            int mat = (offset % NUM_MATERIAL_TYPES),
+                mid = (offset / NUM_MATERIAL_TYPES);
+            gmap->sym.symidx = mons[mid].mlet + SYM_OFF_M;
+            if (mat == objects[STATUE].oc_material || mat == NO_MATERIAL)
+                obj_color(STATUE);
+            else
+                material_color(mat);
             gmap->glyphflags |= (MG_STATUE | MG_MALE | MG_OBJPILE);
         } else if ((offset = (glyph - GLYPH_BODY_PILETOP_OFF)) >= 0) {
             gmap->sym.symidx = objects[CORPSE].oc_class + SYM_OFF_O;
@@ -2642,12 +2623,22 @@ reset_glyphmap(enum glyphmap_change_triggers trigger)
                 material_color(mat);
             gmap->glyphflags |= MG_OBJPILE;
         } else if ((offset = (glyph - GLYPH_STATUE_FEM_OFF)) >= 0) {
-            gmap->sym.symidx = mons[offset].mlet + SYM_OFF_M;
-            obj_color(STATUE);
+            int mat = (offset % NUM_MATERIAL_TYPES),
+                mid = (offset / NUM_MATERIAL_TYPES);
+            gmap->sym.symidx = mons[mid].mlet + SYM_OFF_M;
+            if (mat == objects[STATUE].oc_material || mat == NO_MATERIAL)
+                obj_color(STATUE);
+            else
+                material_color(mat);
             gmap->glyphflags |= (MG_STATUE | MG_FEMALE);
         } else if ((offset = (glyph - GLYPH_STATUE_MALE_OFF)) >= 0) {
-            gmap->sym.symidx = mons[offset].mlet + SYM_OFF_M;
-            obj_color(STATUE);
+            int mat = (offset % NUM_MATERIAL_TYPES),
+                mid = (offset / NUM_MATERIAL_TYPES);
+            gmap->sym.symidx = mons[mid].mlet + SYM_OFF_M;
+            if (mat == objects[STATUE].oc_material || mat == NO_MATERIAL)
+                obj_color(STATUE);
+            else
+                material_color(mat);
             gmap->glyphflags |= (MG_STATUE | MG_MALE);
         } else if ((offset = (glyph - GLYPH_WARNING_OFF))
                    >= 0) { /* warn flash */

--- a/src/do.c
+++ b/src/do.c
@@ -1647,7 +1647,9 @@ goto_level(
 
     /* Reset the screen. */
     vision_reset(); /* reset the blockages */
-    reset_glyphmap(gm_levelchange);
+    /* reset_glyphmap call shouldn't be necessary unless different levels
+       require different glyphmap handling/trigger glyphmap change */
+    /* reset_glyphmap(gm_levelchange); */ 
     docrt(); /* does a full vision recalc */
     flush_screen(-1);
 

--- a/src/pager.c
+++ b/src/pager.c
@@ -250,6 +250,7 @@ object_from_map(int glyph, int x, int y, struct obj **obj_p)
         mtmp = 0;
 
     if (!otmp || otmp->otyp != glyphotyp) {
+        int mat;
         /* this used to exclude STRANGE_OBJECT; now caller deals with it */
         otmp = mksobj(glyphotyp, FALSE, FALSE);
         if (!otmp)
@@ -272,6 +273,10 @@ object_from_map(int glyph, int x, int y, struct obj **obj_p)
         } else if (otmp->otyp == STATUE && glyph_is_statue(glyph)) {
             otmp->corpsenm = glyph_to_statue_corpsenm(glyph);
         }
+        mat = glyph_to_obj_material(glyph);
+        if (mat == NO_MATERIAL)
+            mat = objects[glyphotyp].oc_material;
+        otmp->material = mat;
         if (otmp->otyp == LEASH)
             otmp->leashmon = 0;
         /* extra fields needed for shop price with doname() formatting */

--- a/src/pager.c
+++ b/src/pager.c
@@ -632,9 +632,8 @@ lookat(int x, int y, char *buf, char *monbuf)
     } else if (!glyph_is_cmap(glyph)) {
         Strcpy(buf, "unexplored area");
     } else {
-        int amsk;
+        int amsk, symidx = glyph_to_cmap(glyph);
         aligntyp algn;
-        short symidx = glyph_to_cmap(glyph);
 
         switch (symidx) {
         case S_altar:

--- a/win/share/tilemap.c
+++ b/win/share/tilemap.c
@@ -862,36 +862,40 @@ init_tilemap(void)
 
     /* start of objects */
     file_entry = 0;
-    for (i = 0; i < NUM_OBJECTS; i++) {
-        tilemap[GLYPH_OBJ_OFF + i].tilenum = tilenum;
-        tilemap[GLYPH_OBJ_PILETOP_OFF + i].tilenum = tilenum;
+    for (k = 0; k < NUM_OBJECTS; k++) {
+        for (j = 0; j < NUM_MATERIAL_TYPES; j++) {
+            i = (k * NUM_MATERIAL_TYPES) + j;
+            /* printf("%d + %d = %d\n", k, j, i); */
+            tilemap[GLYPH_OBJ_OFF + i].tilenum = tilenum;
+            tilemap[GLYPH_OBJ_PILETOP_OFF + i].tilenum = tilenum;
 #if defined(OBTAIN_TILEMAP)
-        Snprintf(tilemap[GLYPH_OBJ_OFF + i].name,
-                 sizeof tilemap[GLYPH_OBJ_OFF + i].name,
-                 "%s (onum=%d)",
-                tilename(OBJ_GLYPH, file_entry, 0), i);
-        Snprintf(tilemap[GLYPH_OBJ_PILETOP_OFF + i].name,
-                 sizeof tilemap[GLYPH_OBJ_PILETOP_OFF + i].name,
-                 "%s %s (onum=%d)",
-                 "piletop" ,tilename(OBJ_GLYPH, file_entry, 0), i);
-        add_tileref(tilenum, GLYPH_OBJ_OFF + i,
-                    objects_file, file_entry,
-                    tilemap[GLYPH_OBJ_OFF + i].name, "");
-        add_tileref(tilenum, GLYPH_OBJ_PILETOP_OFF + i,
-                    objects_file, file_entry,
-                    tilemap[GLYPH_OBJ_PILETOP_OFF + i].name, "");
+            Snprintf(tilemap[GLYPH_OBJ_OFF + i].name,
+                    sizeof tilemap[GLYPH_OBJ_OFF + i].name,
+                    "%s (onum=%d, mat=%d)",
+                    tilename(OBJ_GLYPH, file_entry, 0), k, j);
+            Snprintf(tilemap[GLYPH_OBJ_PILETOP_OFF + i].name,
+                    sizeof tilemap[GLYPH_OBJ_PILETOP_OFF + i].name,
+                    "%s %s (onum=%d, mat=%d)",
+                    "piletop" ,tilename(OBJ_GLYPH, file_entry, 0), k, j);
+            add_tileref(tilenum, GLYPH_OBJ_OFF + i,
+                        objects_file, file_entry,
+                        tilemap[GLYPH_OBJ_OFF + i].name, "");
+            add_tileref(tilenum, GLYPH_OBJ_PILETOP_OFF + i,
+                        objects_file, file_entry,
+                        tilemap[GLYPH_OBJ_PILETOP_OFF + i].name, "");
 #endif
+        }
         for (condnum = 0; conditionals[condnum].sequence != -1; condnum++) {
             if (conditionals[condnum].sequence == OBJ_GLYPH
-               && conditionals[condnum].predecessor == i) {
-            tilenum++;
+                && conditionals[condnum].predecessor == k) {
+                tilenum++;
                 file_entry++;
 #if defined(OBTAIN_TILEMAP)
                 Fprintf(tilemap_file, "skipping obj %s (%d)\n",
                         tilename(OBJ_GLYPH, file_entry, 0), file_entry);
 #endif
+            }
         }
-    }
         tilenum++;
         file_entry++;
     }
@@ -1407,7 +1411,7 @@ init_tilemap(void)
                 Fprintf(tilemap_file, "skipping statue of %s (%d)\n",
                         tilename(MON_GLYPH, file_entry, 0), file_entry);
 #endif
-	    }
+            }
         }
         tilenum++;
         file_entry++;

--- a/win/share/tilemap.c
+++ b/win/share/tilemap.c
@@ -1343,7 +1343,7 @@ init_tilemap(void)
 #ifdef STATUES_DONT_LOOK_LIKE_MONSTERS
     /* statue patch: statues still use the same glyph as in 3.4.x */
 
-    for (i = 0; i < NUMMONS; i++) {
+    for (i = 0; i < (NUMMONS * NUM_MATERIAL_TYPES); i++) {
         tilemap[GLYPH_STATUE_OFF + i].tilenum =
             tilemap[GLYPH_OBJ_OFF + STATUE].tilenum;
 #ifdef OBTAIN_TILEMAP
@@ -1360,51 +1360,59 @@ init_tilemap(void)
     /* STATUES _DO_ LOOK LIKE MONSTERS */
     file_entry = 0;
     /* statue patch: statues look more like the monster */
-    for (i = 0; i < NUMMONS; i++) {
-        precheck(GLYPH_STATUE_MALE_OFF + i, "male statues");
-        tilemap[GLYPH_STATUE_MALE_OFF + i].tilenum = tilenum;
-        precheck(GLYPH_STATUE_MALE_PILETOP_OFF + i, "male statue piletop");
-        tilemap[GLYPH_STATUE_MALE_PILETOP_OFF + i].tilenum = tilenum;
+    for (k = 0; k < NUMMONS; k++) {
+        for (j = 0; j < NUM_MATERIAL_TYPES; j++) {
+            i = (k * NUM_MATERIAL_TYPES) + j;
+            precheck(GLYPH_STATUE_MALE_OFF + i, "male statues");
+            tilemap[GLYPH_STATUE_MALE_OFF + i].tilenum = tilenum;
+            precheck(GLYPH_STATUE_MALE_PILETOP_OFF + i, "male statue piletop");
+            tilemap[GLYPH_STATUE_MALE_PILETOP_OFF + i].tilenum = tilenum;
 #if defined(OBTAIN_TILEMAP)
-        Snprintf(tilemap[GLYPH_STATUE_MALE_OFF + i].name,
-                sizeof tilemap[0].name,
-                "statue of male %s (mnum=%d)",
-                tilename(MON_GLYPH, file_entry, 0), file_entry);
-        Snprintf(tilemap[GLYPH_STATUE_MALE_PILETOP_OFF + i].name,
-                sizeof tilemap[0].name,
-                "piletop statue of male %s (mnum=%d)",
-                tilename(MON_GLYPH, file_entry, 0), file_entry);
-        add_tileref(tilenum, GLYPH_STATUE_MALE_OFF + i, generated, file_entry,
-                    tilemap[GLYPH_STATUE_MALE_OFF + i].name,
-                    "");
-        add_tileref(tilenum, GLYPH_STATUE_MALE_PILETOP_OFF + i, generated,
-                    file_entry,
-                    tilemap[GLYPH_STATUE_MALE_PILETOP_OFF + i].name,
-                    "");
+            Snprintf(tilemap[GLYPH_STATUE_MALE_OFF + i].name,
+                     sizeof tilemap[0].name,
+                     "statue of male %s (mnum=%d, mat=%d)",
+                     tilename(MON_GLYPH, file_entry, 0), k, j);
+            Snprintf(tilemap[GLYPH_STATUE_MALE_PILETOP_OFF + i].name,
+                     sizeof tilemap[0].name,
+                     "piletop statue of male %s (mnum=%d, mat=%d)",
+                     tilename(MON_GLYPH, file_entry, 0), k, j);
+            add_tileref(tilenum, GLYPH_STATUE_MALE_OFF + i, generated,
+                        file_entry, tilemap[GLYPH_STATUE_MALE_OFF + i].name,
+                        "");
+            add_tileref(tilenum, GLYPH_STATUE_MALE_PILETOP_OFF + i, generated,
+                        file_entry,
+                        tilemap[GLYPH_STATUE_MALE_PILETOP_OFF + i].name,
+                        "");
 #endif
+        }
         tilenum++;
         file_entry++;
-        precheck(GLYPH_STATUE_FEM_OFF + i, "female statues");
-        tilemap[GLYPH_STATUE_FEM_OFF + i].tilenum = tilenum;
-        precheck(GLYPH_STATUE_FEM_PILETOP_OFF + i, "female statue piletop");
-        tilemap[GLYPH_STATUE_FEM_PILETOP_OFF + i].tilenum = tilenum;
+        for (j = 0; j < NUM_MATERIAL_TYPES; j++) {
+            i = (k * NUM_MATERIAL_TYPES) + j;
+            precheck(GLYPH_STATUE_FEM_OFF + i, "female statues");
+            tilemap[GLYPH_STATUE_FEM_OFF + i].tilenum = tilenum;
+            precheck(GLYPH_STATUE_FEM_PILETOP_OFF + i, "female statue piletop");
+            tilemap[GLYPH_STATUE_FEM_PILETOP_OFF + i].tilenum = tilenum;
 #if defined(OBTAIN_TILEMAP)
-        Snprintf(tilemap[GLYPH_STATUE_FEM_OFF + i].name,
-                sizeof tilemap[0].name,
-                "statue of female %s (mnum=%d)",
-                tilename(MON_GLYPH, file_entry, 0), file_entry);
-        Sprintf(tilemap[GLYPH_STATUE_FEM_PILETOP_OFF + i].name,
-                "piletop statue of female %s (mnum=%d)",
-                tilename(MON_GLYPH, file_entry, 0), file_entry);
-        add_tileref(tilenum, GLYPH_STATUE_FEM_OFF + i, generated, file_entry,
-                    tilemap[GLYPH_STATUE_FEM_OFF + i].name, "");
-        add_tileref(tilenum, GLYPH_STATUE_FEM_PILETOP_OFF + i, generated,
-                    file_entry,
-                    tilemap[GLYPH_STATUE_FEM_PILETOP_OFF + i].name, "");
+            Snprintf(tilemap[GLYPH_STATUE_FEM_OFF + i].name,
+                     sizeof tilemap[0].name,
+                     "statue of female %s (mnum=%d, mat=%d)",
+                     tilename(MON_GLYPH, file_entry, 0), k, j);
+            Snprintf(tilemap[GLYPH_STATUE_FEM_PILETOP_OFF + i].name,
+                     sizeof tilemap[0].name,
+                     "piletop statue of female %s (mnum=%d, mat=%d)",
+                     tilename(MON_GLYPH, file_entry, 0), k, j);
+            add_tileref(tilenum, GLYPH_STATUE_FEM_OFF + i, generated,
+                        file_entry, tilemap[GLYPH_STATUE_FEM_OFF + i].name,
+                        "");
+            add_tileref(tilenum, GLYPH_STATUE_FEM_PILETOP_OFF + i, generated,
+                        file_entry,
+                        tilemap[GLYPH_STATUE_FEM_PILETOP_OFF + i].name, "");
 #endif
+        }
         for (condnum = 0; conditionals[condnum].sequence != -1; condnum++) {
             if (conditionals[condnum].sequence == MON_GLYPH
-                && conditionals[condnum].predecessor == i) {
+                && conditionals[condnum].predecessor == k) {
                 file_entry += 2; /* skip female tile too */
                 tilenum += 2;
 #if defined(OBTAIN_TILEMAP)


### PR DESCRIPTION
Create a glyph for each object/material combination.  This means that
material color is no longer assigned by a somewhat kludgy method that
only works for items present on the floor, but the resulting number of
glyphs is much larger.  There aren't distinct tiles per material; every
material glyph for a particular object shares the same base tileidx.

These changes cover statues and 'normal' objects, but not corpses,
which are only ever generated with their base material as far as I'm
aware -- not much point in adding thousands of corpse material glyphs
which will slow down `reset_glyphmap` but otherwise go unused.  If I'm
wrong and there are actually corpses with non-base materials, this will
require some editing (probably not to incorporate them into the expanded
glyphs, but to reactivate the old `map_glyphinfo` approach for corpses
only).
