### PR TITLE
Fix: monster eating metal container with contents

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1581,6 +1581,7 @@ extern int genus(int, int);
 extern int pm_to_cham(int);
 extern int minliquid(struct monst *);
 extern int movemon(void);
+extern void contents_spill_out(struct obj *, int, int);
 extern int meatmetal(struct monst *);
 extern int meatobj(struct monst *);
 extern int meatcorpse(struct monst *);

--- a/include/extern.h
+++ b/include/extern.h
@@ -1581,7 +1581,7 @@ extern int genus(int, int);
 extern int pm_to_cham(int);
 extern int minliquid(struct monst *);
 extern int movemon(void);
-extern void contents_spill_out(struct obj *, int, int);
+extern void meatbox(struct monst *, struct obj *);
 extern int meatmetal(struct monst *);
 extern int meatobj(struct monst *);
 extern int meatcorpse(struct monst *);

--- a/src/dogmove.c
+++ b/src/dogmove.c
@@ -309,6 +309,21 @@ dog_eat(struct monst *mtmp,
         Strcpy(objnambuf, xname(obj));
         iflags.suppress_price--;
     }
+    /* metallivores may eat a metal container with contents */
+    if (Has_contents(obj)) {
+        struct obj *cobj, *ncobj;
+        if (cansee(mtmp->mx, mtmp->my)) {
+            obj_name = s_suffix(The(distant_name(obj, xname)));
+            pline("%s contents spill out onto the %s.",
+                  obj_name, surface(mtmp->mx, mtmp->my));
+        }
+        for (cobj = obj->cobj; cobj; cobj = ncobj) {
+            ncobj = cobj->nobj;
+            obj_extract_self(cobj);
+            if (!flooreffects(cobj, mtmp->mx, mtmp->my, ""))
+                place_object(cobj, mtmp->mx, mtmp->my);
+        }
+    }
     /* It's a reward if it's DOGFOOD and the player dropped/threw it.
        We know the player had it if invlet is set. -dlc */
     if (dogfood(mtmp, obj) == DOGFOOD && obj->invlet)

--- a/src/dogmove.c
+++ b/src/dogmove.c
@@ -309,9 +309,9 @@ dog_eat(struct monst *mtmp,
         Strcpy(objnambuf, xname(obj));
         iflags.suppress_price--;
     }
-    /* metallivores may eat a metal container with contents */
+    /* metallivores, gelcubes may eat a container with contents */
     if (Has_contents(obj))
-        contents_spill_out(obj, mtmp->mx, mtmp->my);
+        meatbox(mtmp, obj);
     /* It's a reward if it's DOGFOOD and the player dropped/threw it.
        We know the player had it if invlet is set. -dlc */
     if (dogfood(mtmp, obj) == DOGFOOD && obj->invlet)

--- a/src/dogmove.c
+++ b/src/dogmove.c
@@ -310,20 +310,8 @@ dog_eat(struct monst *mtmp,
         iflags.suppress_price--;
     }
     /* metallivores may eat a metal container with contents */
-    if (Has_contents(obj)) {
-        struct obj *cobj, *ncobj;
-        if (cansee(mtmp->mx, mtmp->my)) {
-            obj_name = s_suffix(The(distant_name(obj, xname)));
-            pline("%s contents spill out onto the %s.",
-                  obj_name, surface(mtmp->mx, mtmp->my));
-        }
-        for (cobj = obj->cobj; cobj; cobj = ncobj) {
-            ncobj = cobj->nobj;
-            obj_extract_self(cobj);
-            if (!flooreffects(cobj, mtmp->mx, mtmp->my, ""))
-                place_object(cobj, mtmp->mx, mtmp->my);
-        }
-    }
+    if (Has_contents(obj))
+        contents_spill_out(obj, mtmp->mx, mtmp->my);
     /* It's a reward if it's DOGFOOD and the player dropped/threw it.
        We know the player had it if invlet is set. -dlc */
     if (dogfood(mtmp, obj) == DOGFOOD && obj->invlet)

--- a/src/mon.c
+++ b/src/mon.c
@@ -1264,6 +1264,20 @@ meatmetal(struct monst *mtmp)
                     if (mtmp->mhp > mtmp->mhpmax)
                         mtmp->mhp = mtmp->mhpmax;
                 }
+                if (Has_contents(otmp)) {
+                    struct obj *cobj, *ncobj;
+                    if (cansee(mtmp->mx, mtmp->my) && flags.verbose) {
+                        otmpname = s_suffix(The(distant_name(otmp, xname)));
+                        pline("%s contents spill out onto the %s.",
+                              otmpname, surface(mtmp->mx, mtmp->my));
+                    }
+                    for (cobj = otmp->cobj; cobj; cobj = ncobj) {
+                        ncobj = cobj->nobj;
+                        obj_extract_self(cobj);
+                        if (!flooreffects(cobj, mtmp->mx, mtmp->my, ""))
+                            place_object(cobj, mtmp->mx, mtmp->my);
+                    }
+                }
                 if (otmp == uball) {
                     unpunish();
                     delobj(otmp);

--- a/src/mon.c
+++ b/src/mon.c
@@ -1196,6 +1196,25 @@ movemon(void)
     return somebody_can_move;
 }
 
+void
+contents_spill_out(struct obj *otmp, int x, int y)
+{
+    struct obj *cobj, *ncobj;
+    if (!Has_contents(otmp))
+        return;
+    if (cansee(x, y)) {
+        pline("%s contents spill out onto the %s.",
+              s_suffix(The(distant_name(otmp, xname))),
+              surface(x, y));
+    }
+    for (cobj = otmp->cobj; cobj; cobj = ncobj) {
+        ncobj = cobj->nobj;
+        obj_extract_self(cobj);
+        if (!flooreffects(cobj, x, y, ""))
+            place_object(cobj, x, y);
+    }
+}
+
 #define mstoning(obj)                                       \
     (ofood(obj) && (touch_petrifies(&mons[(obj)->corpsenm]) \
                     || (obj)->corpsenm == PM_MEDUSA))
@@ -1264,20 +1283,8 @@ meatmetal(struct monst *mtmp)
                     if (mtmp->mhp > mtmp->mhpmax)
                         mtmp->mhp = mtmp->mhpmax;
                 }
-                if (Has_contents(otmp)) {
-                    struct obj *cobj, *ncobj;
-                    if (cansee(mtmp->mx, mtmp->my) && flags.verbose) {
-                        otmpname = s_suffix(The(distant_name(otmp, xname)));
-                        pline("%s contents spill out onto the %s.",
-                              otmpname, surface(mtmp->mx, mtmp->my));
-                    }
-                    for (cobj = otmp->cobj; cobj; cobj = ncobj) {
-                        ncobj = cobj->nobj;
-                        obj_extract_self(cobj);
-                        if (!flooreffects(cobj, mtmp->mx, mtmp->my, ""))
-                            place_object(cobj, mtmp->mx, mtmp->my);
-                    }
-                }
+                if (Has_contents(otmp))
+                    contents_spill_out(otmp, mtmp->mx, mtmp->my);
                 if (otmp == uball) {
                     unpunish();
                     delobj(otmp);


### PR DESCRIPTION
A metallivore monster eating a metal container with contents would cause a
~memory leak~ (edit: actually not a memory leak, the contents do get properly
freed), as the contents would disappear (for all intents and purposes)
without being freed.  Change this so that the contents fall onto the floor.
I wrote this a few days ago but I think I wasn't completely satisfied with
it at the time.  I can't remember exactly why that was, though, so I am
opening this PR for review -- it can always be closed if it turns out there
really is some showstopper problem that I have forgotten.

- Fix: metallivore eating metal container
- Move duplicate code (eating boxes) into function
