### PR TITLE
Fix: hitting ghost with blessed non-weapon

### DIFF
--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -1780,7 +1780,8 @@ shade_aware(struct obj *obj)
         || obj->otyp == MIRROR          /* silver in the reflective surface */
         || obj->otyp == CLOVE_OF_GARLIC /* causes shades to flee */
         || obj->material == SILVER
-        || obj->material == BONE)
+        || obj->material == BONE
+        || obj->blessed)
         return TRUE;
     return FALSE;
 }


### PR DESCRIPTION
Hitting a noncorporeal monster with a blessed non-weapon (such as a
piece of armor) didn't deal any damage, but produced messaging as though
it had.  Including blessed items in shade_aware seems to fix this,
hopefully without introducing any new bugs.
