### PR TITLE
Fix: buffer overflow when entering long epitaph

### DIFF
--- a/src/end.c
+++ b/src/end.c
@@ -1556,10 +1556,11 @@ really_done(int how)
         pbuf[0] = '\0';
         if (yn("Do you want to write your own epitaph?") == 'y') {
             char ebuf[BUFSZ];
+            ebuf[0] = '\0'; /* don't show junk for EDIT_GETLIN */
             getlin("Enter your epitaph:", ebuf);
             if (*ebuf) {
                 Sprintf(pbuf, "%s.  ", g.plname);
-                (void) strncat(pbuf, ebuf, sizeof pbuf - Strlen(pbuf) - 1);
+                (void) strncat(pbuf, ebuf, 100);
             }
         }
         if (!*pbuf) { /* didn't write own epitaph, or entered a blank line */

--- a/src/end.c
+++ b/src/end.c
@@ -1553,15 +1553,18 @@ really_done(int how)
              * any vitality to stop it) */
             corpse = mk_named_object(CORPSE, &mons[mnum], u.ux, u.uy, g.plname);
         }
-        if (yn("Do you want to write your own epitaph?") != 'y') {
+        pbuf[0] = '\0';
+        if (yn("Do you want to write your own epitaph?") == 'y') {
+            char ebuf[BUFSZ];
+            getlin("Enter your epitaph:", ebuf);
+            if (*ebuf) {
+                Sprintf(pbuf, "%s.  ", g.plname);
+                (void) strncat(pbuf, ebuf, sizeof pbuf - Strlen(pbuf) - 1);
+            }
+        }
+        if (!*pbuf) { /* didn't write own epitaph, or entered a blank line */
             Sprintf(pbuf, "%s, ", g.plname);
             formatkiller(eos(pbuf), sizeof pbuf - Strlen(pbuf), how, TRUE);
-        }
-        else {
-            char ebuf[101]; /* arbitrary, but should be enough */
-            getlin("Enter your epitaph (100 characters max):", ebuf);
-            ebuf[100] = '\0';
-            Sprintf(pbuf, "%s. %s", g.plname, ebuf);
         }
         make_grave(u.ux, u.uy, pbuf);
     }


### PR DESCRIPTION
Providing a char[101] buffer to getlin didn't actually limit user input
to 100 characters; instead it ensured anything longer would end up
written past the end of the buffer.  Not possible in TTY (since for some
reason getlin input length is limited to COLNO, getline.c:146) but in
curses this could be done and cause a crash on some platforms, or
potentially be put to some other malicious end.  Prevent this from
happening (and remove the 100 character limit, since it's not actually
enforced when entering text; instead, limit the full epitaph to the size
of the buffer).

I also changed things around so that selecting to enter your own
epitaph, but then entering an empty line, will use the default
formatkiller headstone engraving.
