### PR TITLE
Fix: mon stayed hidden when concealing obj deleted

### DIFF
--- a/src/mon.c
+++ b/src/mon.c
@@ -4415,7 +4415,7 @@ maybe_unhide_at(xchar x, xchar y)
 {
     struct monst *mtmp;
 
-    if (!concealed_spot(x, y))
+    if (concealed_spot(x, y))
         return;
     if ((mtmp = m_at(x, y)) == 0 && u_at(x, y))
         mtmp = &g.youmonst;


### PR DESCRIPTION
maybe_unhide_at was supposed to return early and not try to unhide the
monster if conditions were still valid for hiding.  The test was
backwards, so instead it returned early if the monster had nowhere left
to hide, causing monsters to remain hidden even after their concealing
object/terrain was removed.
