### PR TITLE
Avoid "killed by a died" from open air fall

### DIFF
--- a/src/dungeon.c
+++ b/src/dungeon.c
@@ -1368,8 +1368,8 @@ find_level_beneath(const d_level *start, d_level *beneath)
     }
     else if (br && br->type == BR_STAIR && builds_up((d_level *) start)) {
         /* In Vlad's Tower cavern (or theoretically some other branch that
-            * grows upwards and is physically connected to the parent branch by a
-            * stairway), fall to that parent branch level beneath it */
+         * grows upwards and is physically connected to the parent branch by a
+         * stairway), fall to that parent branch level beneath it */
         if (br->end1.dnum == start->dnum)
             *beneath = br->end2;
         else

--- a/src/hack.c
+++ b/src/hack.c
@@ -2860,6 +2860,8 @@ u_aireffects(void)
         else {
             pline("Unfortunately, there is still nowhere safe to land.");
             You("fall to your death again.");
+            Sprintf(g.killer.name, "fell to %s death", uhis());
+            g.killer.format = NO_KILLER_PREFIX;
             done(DIED);
         }
     }


### PR DESCRIPTION
The second call to done() if falling into a bottomless pit (used only if
the hero was lifesaved for the first one, then no safe teleport
destination could be found) could produce "killed by a died" as the
death reason.  Since g.killer.name is reset by done() after the hero
survives, and wasn't being set again before the second call, it would be
left empty and the (somewhat nonsensical) default death reason would be
used.  I don't think there are currently any bottomless pits in the
game, so this was a latent bug.
