### PR TITLE
Make beartraps stackable

### DIFF
--- a/include/objects.h
+++ b/include/objects.h
@@ -811,7 +811,7 @@ TOOL("magic marker",        NoDes, 1, 0, 1, 1, 15,  2,200, PLASTIC, CLR_RED,
 /* traps */
 TOOL("land mine",           NoDes, 1, 0, 0, 0, 0,  40,180, IRON, CLR_RED,
                                                                 LAND_MINE),
-TOOL("beartrap",            NoDes, 1, 0, 0, 0, 0,  50, 60, IRON, HI_METAL,
+TOOL("beartrap",            NoDes, 1, 1, 0, 0, 0,  50, 60, IRON, HI_METAL,
                                                                 BEARTRAP),
 /* instruments */
 TOOL("pea whistle",    "whistle", 0, 0, 0, 0,100, 3, 10, METAL, HI_METAL,


### PR DESCRIPTION
Rangers start with a stack of beartraps, but because they were marked
!oc_merge, once the stack was split by placing one of them, the
beartraps could never be restacked (nor could the stack be supplemented
with additional beartraps from the dungeon).
