### PR TITLE
Fix #103: dismounting steed over open air/chasm

### DIFF
--- a/src/steal.c
+++ b/src/steal.c
@@ -787,12 +787,12 @@ relobj(
     } /* isgd && has gold */
 
     while ((otmp = (is_pet ? droppables(mtmp) : mtmp->minvent)) != 0) {
-        mdrop_obj(mtmp, otmp, is_pet && flags.verbose);
         if (is_unpaid(otmp) && costly_spot(omx, omy)
             && (shkp = shop_keeper(*in_rooms(omx, omy, SHOPBASE))) != 0
             && inhishop(shkp)) {
             subfrombill(otmp, shkp);
         }
+        mdrop_obj(mtmp, otmp, is_pet && flags.verbose);
     }
 
     if (show && cansee(omx, omy))


### PR DESCRIPTION
dismount_steed() was failing to check that the monster was grounded
before calling mon_aireffects() and consigning it to splat on the
distant floor.  This, combined with landing_spot() using Flying (which
the hero's flying steed contributes to) as reason to consider open air
as a safe dismount position, caused some potentially-deadly problems
(both for the hero and her steed) when dismounting over a chasm.  Should
fix #103.
