### PR TITLE
Fix: 'is' vs 'tastes' palatable adjective tags

### DIFF
--- a/src/eat.c
+++ b/src/eat.c
@@ -1985,8 +1985,10 @@ eatcorpse(struct obj *otmp)
                     "Tokay", "Istringy", "Igamey", "Ifatty", "Itough"
                 };
                 int idx = vegetarian(&mons[mnum]) ? 0 : rn2(SIZE(palatable_msgs));
-                taste = &palatable_msgs[idx][1];
+                taste = palatable_msgs[idx];
+                /* use and discard the 'T' or 'I' tag */
                 use_is = (*taste == 'I');
+                taste++;
             }
             else
                 taste = "terrible";


### PR DESCRIPTION
The character used to tag the 'palatable food' adjectives as taking 'is'
or 'tastes' ('...tastes okay' vs '...is fatty') was being discarded
without being processsed/used, so 'tastes' was being used with every
adjective.
