### PR TITLE
Fix: articles in dropping-cursed-gold messages

### DIFF
--- a/src/do.c
+++ b/src/do.c
@@ -698,8 +698,8 @@ canletgo(struct obj *obj, const char *word)
     }
     if (undroppable(obj)) {
         if (*word) {
-            pline("For some reason, you cannot %s%s the %s!", word,
-                  obj->quan > 1 ? " any of" : "", xname(obj));
+            pline("For some reason, you cannot %s%s %s!", word,
+                  obj->quan > 1 ? " any of" : "", the(xname(obj)));
         }
         set_bknown(obj, 1);
         return FALSE;

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -2808,7 +2808,7 @@ in_container(struct obj *obj)
         return 0;
     } else if (undroppable(obj)) {
         set_bknown(obj, 1);
-        pline("%s won't leave your person.", xname(obj));
+        pline("%s won't leave your person.", The(xname(obj)));
         return 0;
     } else if (obj->otyp == AMULET_OF_YENDOR
                || obj->otyp == CANDELABRUM_OF_INVOCATION


### PR DESCRIPTION
When trying to insert a cursed gold item into a container, the message
started with the (lowercase) object name, sans article -- e.g.  "gold
ring won't leave your person".  Make sure 'The' is included at the start
of the pline when needed.

On the other hand, 'the' was hardcoded into the format string when
failing to drop items with 'd'/'D', so the article was included even if
it didn't belong (e.g. trying to drop cursed Itlachiayaque).  Use the()
there instead.
