### PR TITLE
Fix: hanging when loading Val-loca.lua

### DIFF
--- a/src/cmd.c
+++ b/src/cmd.c
@@ -1868,15 +1868,16 @@ wiz_map_levltyp(void)
 
 /* temporary? hack, since level type codes aren't the same as screen
    symbols and only the latter have easily accessible descriptions */
-const char *levltyp[] = {
+const char *levltyp[MAX_TYPE + 2] = {
     "stone", "vertical wall", "horizontal wall", "top-left corner wall",
     "top-right corner wall", "bottom-left corner wall",
     "bottom-right corner wall", "cross wall", "tee-up wall", "tee-down wall",
     "tee-left wall", "tee-right wall", "drawbridge wall", "tree",
     "secret door", "secret corridor", "pool", "moat", "water",
-    "drawbridge up", "lava pool", "iron bars", "door", "corridor", "room",
-    "stairs", "ladder", "fountain", "throne", "sink", "grave", "altar", "ice",
-    "drawbridge down", "air", "cloud",
+    "drawbridge up", "lava pool", "lava wall", "iron bars", "door",
+    "corridor", "room", "stairs", "ladder", "fountain", "throne", "sink",
+    "grave", "altar", "ice", "grass", "magic platform", "drawbridge down",
+    "air", "cloud",
     /* not a real terrain type, but used for undiggable stone
        by wiz_map_levltyp() */
     "unreachable/undiggable",


### PR DESCRIPTION
This level tries to generate a clear path through the ice on the left
hand side of the screen, which involves retrieving the name of the
terrain type and comparing it against a list of allowed types.  However,
the array of terrain type names had desynced from the actual list of
terrain types, causing it to produce the wrong names so that it would
never actually certify the path as "good to go".  Fix this by
resynchronizing the lists, and add an explicit length to the terrain
type names list based on the enum so that it will produce a compiler
error if more terrains are added in the future without fixing the
terrain name list.
