### PR TITLE
A number of additional effects should wake up monsters

### DIFF
--- a/src/eat.c
+++ b/src/eat.c
@@ -2149,6 +2149,10 @@ fprefx(struct obj *otmp)
             break;
         }
         goto give_feedback;
+    case CARROT:
+        pline("Crunch!");
+        wake_nearby();
+        goto give_feedback;
     case MEATBALL:
     case MEAT_STICK:
     case ENORMOUS_MEATBALL:

--- a/src/spell.c
+++ b/src/spell.c
@@ -466,6 +466,14 @@ study_book(register struct obj* spellbook)
         }
     }
 
+    /* attempting to read a dusty book may result in sneezing */
+    if (objdescr_is(spellbook, "dusty") && !rn2(5)
+        && olfaction(gy.youmonst.data)) {
+        pline("Some dust from the book gets in your %s and you violently sneeze!", body_part(NOSE));
+        wake_nearby();
+        return 1;
+    }
+
     if (gc.context.spbook.delay && !confused
         && spellbook == gc.context.spbook.book
         /* handle the sequence: start reading, get interrupted, have

--- a/src/trap.c
+++ b/src/trap.c
@@ -1499,6 +1499,13 @@ trapeffect_sqky_board(
         }
         /* wake up nearby monsters */
         wake_nearto(mtmp->mx, mtmp->my, 40);
+        /* wake the hero if nearby */
+        if (u.usleep && u.usleep < gm.moves
+            && dist2(mtmp->mx, mtmp->my, u.ux, u.uy) < 40
+            && !(EDeaf || u.uroleplay.deaf)) {
+            gm.multi = -1;
+            gn.nomovemsg = "The squeak awakens you.";
+        }
     }
     return Trap_Effect_Finished;
 }
@@ -3322,6 +3329,9 @@ launch_obj(
                 stop_occupation();
         }
         if (style == ROLL) {
+            if (otyp == BOULDER) {
+                wake_nearto(gb.bhitpos.x, gb.bhitpos.y, 25);
+            }
             if (down_gate(gb.bhitpos.x, gb.bhitpos.y) != -1) {
                 if (ship_object(singleobj, gb.bhitpos.x, gb.bhitpos.y, FALSE)) {
                     used_up = TRUE;


### PR DESCRIPTION
Implements #139

Regarding: "monsters stepping on a squeaky board near you when you are asleep should wake YOU up". It seems like being Deaf should prevent you waking up from sounds. However, falling asleep also makes the hero Deaf, which means that a squeaky board would never wake the hero up. My proposed solution is to wake up the hero unless they have extrinsic deafness (EDeaf) or are roleplaying deafness (u.uroleplay.deaf).

Thoughts?