### PR TITLE
Pets consider intrinsic-granting corpses treats

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -1644,6 +1644,7 @@ extern void m_consume_obj(struct monst *, struct obj *);
 extern int meatmetal(struct monst *);
 extern int meatobj(struct monst *);
 extern int meatcorpse(struct monst *);
+extern boolean mon_wants_prop(struct permonst *, struct monst *);
 extern void mon_give_prop(struct monst *, int);
 extern void mon_givit(struct monst *, struct permonst *);
 extern void mpickgold(struct monst *);

--- a/src/dog.c
+++ b/src/dog.c
@@ -1022,7 +1022,8 @@ dogfood(struct monst *mon, struct obj *obj)
             else if (is_shapeshifter(fptr) && mon->mtame > 1 && !starving)
                 return MANFOOD;
             else if (vegan(fptr))
-                return herbi ? CADAVER : MANFOOD;
+                return herbi ? (mon_wants_prop(fptr, mon) ? DOGFOOD : CADAVER)
+                             : MANFOOD;
             /* most humanoids will avoid cannibalism unless starving;
                arbitrary: elves won't eat other elves even then */
             else if (humanoid(mptr) && same_race(mptr, fptr)
@@ -1030,7 +1031,8 @@ dogfood(struct monst *mon, struct obj *obj)
                          && fptr->mlet != S_ORC && fptr->mlet != S_OGRE))
                 return (starving && carni && !is_elf(mptr)) ? ACCFOOD : TABU;
             else
-                return carni ? CADAVER : MANFOOD;
+                return carni ? (mon_wants_prop(fptr, mon) ? DOGFOOD : CADAVER)
+                             : MANFOOD;
         case GLOB_OF_GREEN_SLIME: /* other globs use the default case */
             /* turning into slime is preferable to starvation */
             return (starving || slimeproof(mon->data)) ? ACCFOOD : POISON;

--- a/src/mon.c
+++ b/src/mon.c
@@ -1636,6 +1636,27 @@ meatcorpse(
     return 0;
 }
 
+/* does the corpse convey an intrinsic that the monster doesn't have yet? */
+boolean
+mon_wants_prop(struct permonst *ptr, struct monst *mon)
+{
+#define mon_has_intrinsic(intrinsic, mon) \
+    ((((mon)->mintrinsics | (mon)->data->mresists) & intrinsic) != 0UL)
+    int i;
+
+    for (i = 1; i <= STONE_RES; i++) {
+        if (intrinsic_possible(i, ptr)
+            && !mon_has_intrinsic((1 << (i - 1)), mon)) {
+            return TRUE;
+        }
+    }
+    if (intrinsic_possible(TELEPAT, ptr)
+        && !(mon_has_intrinsic(MR2_TELEPATHY, mon) || telepathic(mon->data)))
+        return TRUE;
+
+    return FALSE;
+}
+
 /* give monster property prop */
 void
 mon_give_prop(struct monst *mtmp, int prop)


### PR DESCRIPTION
Pets will prefer corpses which grant intrinsics they don't yet have, and
respond to them like treats (e.g. will catch a thrown one).  This will
not overcome their natural vegetarian or carnivorous inclinations, just
affects how they feel about corpses that they would already be willing
to eat.

From 05492fcbf776084cb5cf40cab4fd3f1d80a5d76a in EvilHack.
