### PR TITLE
Avoid "mysterious" (and other materials) descriptions in #call prompt

### DIFF
--- a/include/objclass.h
+++ b/include/objclass.h
@@ -213,4 +213,15 @@ extern NEARDATA struct objdescr obj_descr[NUM_OBJECTS + 1];
     (is_rustprone(otmp) || is_flammable(otmp) || is_rottable(otmp) \
      || is_corrodeable(otmp))
 
+/* Force rendering of materials on certain items where the object name
+ * wouldn't make as much sense without a material (e.g. "leather jacket" vs
+ * "jacket"), or those where the default material is non-obvious.
+ * NB: GLOVES have a randomized description when not identified; "leather
+ * padded gloves" would give the game away if we did not check their
+ * identification status */
+#define force_material_name(typ) \
+    ((typ) == LIGHT_ARMOR || (typ) == STUDDED_ARMOR || (typ) == JACKET \
+     || (typ) == PLAIN_CLOAK || (typ) == FIGURINE || (typ) == STATUE \
+     || ((typ) == GLOVES && objects[GLOVES].oc_name_known))
+
 #endif /* OBJCLASS_H */

--- a/src/do_name.c
+++ b/src/do_name.c
@@ -1783,6 +1783,10 @@ docall_xname(struct obj *obj)
     otemp.quan = 1L;
     /* in case water is already known, convert "[un]holy water" to "water" */
     otemp.blessed = otemp.cursed = 0;
+    /* drop material from name unless it's really mandatory */
+    if (!force_material_name(otemp.otyp)) {
+        otemp.material = objects[otemp.otyp].oc_material;
+    }
     /* remove attributes that are doname() caliber but get formatted
        by xname(); most of these fixups aren't really needed because the
        relevant type of object isn't callable so won't reach this far */

--- a/src/o_init.c
+++ b/src/o_init.c
@@ -1092,6 +1092,7 @@ rename_disco(void)
             odummy.oclass = objects[dis].oc_class;
             odummy.quan = 1L;
             odummy.known = !objects[dis].oc_uses_known;
+            odummy.material = objects[dis].oc_material;
             odummy.dknown = 1;
             docall(&odummy);
         }

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -525,17 +525,6 @@ xname(struct obj* obj)
     return xname_flags(obj, CXN_NORMAL);
 }
 
-/* Force rendering of materials on certain items where the object name
- * wouldn't make as much sense without a material (e.g. "leather jacket" vs
- * "jacket"), or those where the default material is non-obvious.
- * NB: GLOVES have a randomized description when not identified; "leather
- * padded gloves" would give the game away if we did not check their
- * identification status */
-#define force_material_name(typ) \
-    ((typ) == LIGHT_ARMOR || (typ) == STUDDED_ARMOR || (typ) == JACKET \
-     || (typ) == PLAIN_CLOAK || (typ) == FIGURINE || (typ) == STATUE \
-     || ((typ) == GLOVES && objects[GLOVES].oc_name_known))
-
 static char *
 xname_flags(
     register struct obj *obj,


### PR DESCRIPTION
This fixes an issue where most #call prompts via the discovery list
would describe the item being renamed as "mysterious" (e.g. "Call a
pair of mysterious gloves"), because the dummy object created for that
purpose wasn't being assigned any material.

Then I went further and dropped material names from all #call prompts
(other than items which always include a material in their name, though
that's largely theoretical since most aren't callable), since you are
naming the item type, not the particular item.  You are calling all
"etched helmets" something, not all "silver etched helmets", and I think
it makes sense for the prompt to reflect that.  Prompts to name a
particular item would still include the material.