### PR TITLE
Fix non-ascii characters in encyclopedia

### DIFF
--- a/dat/data.base
+++ b/dat/data.base
@@ -4305,7 +4305,7 @@ pancake
 	"Wait." Wyndle zipped forward, leaving a trail of vines and
 	crystal behind. He grew up the back of the chull cart, curling
 	onto its wood right in front of her. He made a face there, looking
-	at her. "Is that why we left all of a sudden? Is that why we’re
+	at her. "Is that why we left all of a sudden? Is that why we're
 	here? Did you come chasing that monster?"
 	"Course not," Lift said, hands in her pockets. "That would be
 	stupid."
@@ -4314,7 +4314,7 @@ pancake
 	"Then why are we here?"
 	"They got these pancakes here," she said, "with things cooked into
 	them. Supposed to be super tasty, and they eat them during the
-	Weeping. Ten varieties. I’m gonna steal one of each."
+	Weeping. Ten varieties. I'm gonna steal one of each."
 	"You came all this way, leaving behind luxury, to eat some
 	pancakes."
 	"Really awesome pancakes."
@@ -5430,19 +5430,19 @@ stair*
 		[ Ghostbusters, directed by Ivan Reitman,
 		  written by Dan Ackroyd and Harold Ramis ]
 *stalker
-	“You don’t understand,” he said, “who I am or what I am. I’ll show
-	you. By Heaven! I’ll show you.” Then he put his open palm over his
+	"You don't understand," he said, "who I am or what I am. I'll show
+	you. By Heaven! I'll show you." Then he put his open palm over his
 	face and withdrew it. The centre of his face became a black
-	cavity. “Here,” he said. He stepped forward and handed Mrs. Hall
+	cavity. "Here," he said. He stepped forward and handed Mrs. Hall
 	something which she, staring at his metamorphosed face, accepted
 	automatically. Then, when she saw what it was, she screamed
-	loudly, dropped it, and staggered back. The nose—it was the
-	stranger’s nose! pink and shining—rolled on the floor.
+	loudly, dropped it, and staggered back. The nose--it was the
+	stranger's nose! pink and shining—rolled on the floor.
 
 	Then he removed his spectacles, and everyone in the bar gasped. He
 	took off his hat, and with a violent gesture tore at his whiskers
 	and bandages. For a moment they resisted him. A flash of horrible
-	anticipation passed through the bar. “Oh, my Gard!” said some one.
+	anticipation passed through the bar. "Oh, my Gard!" said some one.
 	Then off they came.
 
 	It was worse than anything. Mrs. Hall, standing open-mouthed and
@@ -5453,7 +5453,7 @@ stair*
 	hobbledehoy jump to avoid them. Everyone tumbled on everyone else
 	down the steps. For the man who stood there shouting some
 	incoherent explanation, was a solid gesticulating figure up to the
-	coat-collar of him, and then—nothingness, no visible thing at all!
+	coat-collar of him, and then--nothingness, no visible thing at all!
 		[ The Invisible Man, by H. G. Wells ]
 ~statue trap
 statue*


### PR DESCRIPTION
Em dashes (—) and curly quotes and apostrophes (‘’“”) may not display correctly. Replaced them with ASCII substitutions: double hyphen-minus (--) and straight quote and apos ('")