### PR TITLE
Fix MR not working vs Paralyze spell

### DIFF
--- a/src/mcastu.c
+++ b/src/mcastu.c
@@ -1021,9 +1021,10 @@ cast_cleric_spell(struct monst *mtmp, int dmg, int spellnum)
         if (Antimagic) {
             shieldeff(u.ux, u.uy);
             monstseesu(M_SEEN_MAGR);
+            dmg = 1;
         }
         dynamic_multi_reason(mtmp, "paralyzed", FALSE);
-        make_paralyzed(dmg, FALSE, (const char *) 0);
+        make_paralyzed(dmg, TRUE, (const char *) 0);
         dmg = 0;
         break;
     case CLC_CONFUSE_YOU:


### PR DESCRIPTION
Magic resistance was doing nothing to reduce or negate the paralysis caused by the Paralyze monster spell, despite being noticed by the caster and showing the sparkle animation. Now MR cuts the duration to 1 turn, like vanilla. (Free action still negates it fully, as handled by make_paralyzed.) Also fixed the spell's paralysis messages being suppressed.