### PR TITLE
Fix: Orcus lair wall gap "fallback"

### DIFF
--- a/dat/orcus.lua
+++ b/dat/orcus.lua
@@ -77,7 +77,7 @@ leftwall:iterate(function(x,y)
    end
 end)
 if not madegap then
-   des.terrain(03,10, '-') -- failsafe
+   des.terrain(03,10, '.') -- failsafe
 end
 
 -- Doors


### PR DESCRIPTION
A player recently got an Orcus level where the wall had no gap, so the
level was completely inaccessible.  Looks to me like this was because
the intended fallback position for failure to create any random gaps was
replacing the vertical wall with a horizontal wall, rather than with a
gap.
